### PR TITLE
Scylla-Elasticsearch integration example, used also in a doc + upcoming blog

### DIFF
--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -105,7 +105,7 @@ cqlsh> SELECT COUNT (*) FROM catalog.apparel ;
 (1 rows)
 ```
 
-7. Run the “query_data” script. The script will perform the following:
+7. Run the *“query_data”* script. The script will perform the following:
 	- Textual search in Elasticsearch using single / multiple filter/s, or no filter (match_all)
 	- Use the Elasticsearch results to query Scylla (using prepared statement)
 

--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -1,0 +1,136 @@
+General Info and Prerequisites
+==============================
+
+The following example creates an apparel catalog stored on Scylla, and searchable using Elasticsearch (ES).      
+We will be using two python scripts to demonstrate the integration of Scylla with Elasticsearch.
+- Dual writes using the “insert_data” script for data ingestion, in our case an apparel catalog csv file.
+- Textual search using the “query_data” script, a 2-hop query that will retrieve the unique product_id (SKU) from Elasticsearch and then use the SKU to retrieve all the other product attributes from Scylla.
+
+
+**Pre-requisites**
+- [python installed](https://www.python.org/download/releases/2.7/)
+- [pip installed](https://packaging.python.org/guides/installing-using-linux-tools/)
+- [Java 8 installed](http://openjdk.java.net/install/)
+- [Scylla cluster up and running](https://www.scylladb.com/download/)
+- An instance for Elasticsearch installation and python scripts (can be separate instances)
+
+
+
+Instructions
+============
+
+**Procedure**
+1. Install the python drivers on the node to be used for the scripts
+```
+$ sudo pip install cassandra-driver
+$ sudo pip install elasticsearch
+```
+
+2. Install [Elasticsearch](https://www.elastic.co/guide/en/beats/libbeat/current/elasticsearch-installation.html)
+```
+$ sudo apt-get update
+$ curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.3.deb 
+$ sudo dpkg -i elasticsearch-6.2.3.deb
+```
+
+3. Start Elasticsearch, verify status and health state
+```
+$ sudo /etc/init.d/elasticsearch start
+[ ok ] Starting elasticsearch (via systemctl): elasticsearch.service.
+```
+```
+curl http://127.0.0.1:9200/_cluster/health?pretty 
+{
+  "cluster_name" : "elasticsearch",
+  "status" : "green",
+  "timed_out" : false,
+  "number_of_nodes" : 1,
+  "number_of_data_nodes" : 1,
+  "active_primary_shards" : 0,
+  "active_shards" : 0,
+  "relocating_shards" : 0,
+  "initializing_shards" : 0,
+  "unassigned_shards" : 0,
+  "delayed_unassigned_shards" : 0,
+  "number_of_pending_tasks" : 0,
+  "number_of_in_flight_fetch" : 0,
+  "task_max_waiting_in_queue_millis" : 0,
+  "active_shards_percent_as_number" : 100.0
+}
+```
+
+4. Copy the files to the location from which you will run them, and make them executable
+	- catalog.csv (the SKU is the unique product_id, made of other product attributes initials)
+	- insert_data_into_scylla+elastic.py
+	- query_data_from_scylla+elastic.py
+
+5. Run the “insert_data” script. The script will perform the following:
+	- Create the Schema on Scylla (see Appendix-A)
+	- Create the Elasticsearch index (see Appendix-A)
+	- Dual write: insert the catalog items (csv file) to both DBs (using prepared statement for Scylla)
+
+Use the ```-s | -e``` flags to insert a comma-separated list of IPs for the Scylla and Elasticsearch (ES) nodes.
+If you are running Elasticsearch (ES) on the same node as the python scripts, no need to enter IP, default 127.0.0.1 will be used.
+
+```
+$ python insert_data_into_scylla+elastic.py -h
+	usage: insert_data_into_scylla+elastic.py [-h] [-s SCYLLA_IP] [-e ES_IP]
+
+	optional arguments:
+	  -h, --help    show this help message and exit
+	  -s SCYLLA_IP
+	  -e ES_IP
+```
+
+6. Once the “insert_data” script completes, you will find 160 entries in both Scylla and Elasticsearch
+```
+$ curl http://127.0.0.1:9200/catalog/_count/?pretty
+{
+  "count" : 160,
+  "_shards" : {
+    "total" : 5,
+    "successful" : 5,
+    "skipped" : 0,
+    "failed" : 0
+  }
+}
+```
+```
+cqlsh> SELECT COUNT (*) FROM catalog.apparel ;
+
+ count
+-------
+   160
+
+(1 rows)
+```
+
+7. Run the “query_data” script. The script will perform the following:
+	- Textual search in Elasticsearch using single / multiple filter/s, or no filter (match_all)
+	- Use the Elasticsearch results to query Scylla (using prepared statement)
+
+Use the ```-s | -e``` flags to insert a comma-separated list of IPs for the Scylla and Elasticsearch nodes.
+If you are running Elasticsearch on the same node as the python scripts, no need to enter IP, default 127.0.0.1 will be used.
+
+Use the -n flag to select the query type. The optional values are:
+	- **single**: using a single filter (by group) to query for *“pants”*
+	- **multiple (default)**: using multiple filters (by color and sub_group) to query for *"white softshell"*
+	- **none**: query without any filter = *match_all*
+
+Note: Elasticsearch returns only the 1st 10 results by default. To overcome this we set the size limit to 1000 results. For large result we recommend using pagination (read more here: [elasticsearch-py helpers](http://elasticsearch-py.readthedocs.io/en/master/helpers.html?highlight=scroll)).
+
+```
+$ python query_data_from_scylla+elastic.py -h
+usage: query_data_from_scylla+elastic.py [-h] [-s SCYLLA_IP] [-e ES_IP] [-n NUM_FILTERS]
+
+optional arguments:
+  -h, --help      show this help message and exit
+  -s SCYLLA_IP
+  -e ES_IP
+  -n NUM_FILTERS
+```
+
+8. To delete Elasticsearch index and the keyspace in Scylla run the following commands
+	- **Elasticsearch**:  ```$ curl -X DELETE "127.0.0.1:9200/catalog"```
+	- **Scylla**:  ```cqlsh> DROP KEYSPACE catalog ;```
+

--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -65,8 +65,8 @@ curl http://127.0.0.1:9200/_cluster/health?pretty
 	- query_data_from_scylla+elastic.py
 
 5. Run the “insert_data” script. The script will perform the following:
-	- Create the Schema on Scylla (see Appendix-A)
-	- Create the Elasticsearch index (see Appendix-A)
+	- Create the Schema on Scylla
+	- Create the Elasticsearch index
 	- Dual write: insert the catalog items (csv file) to both DBs (using prepared statement for Scylla)
 
 Use the ```-s | -e``` flags to insert a comma-separated list of IPs for the Scylla and Elasticsearch (ES) nodes.
@@ -112,7 +112,7 @@ cqlsh> SELECT COUNT (*) FROM catalog.apparel ;
 Use the ```-s | -e``` flags to insert a comma-separated list of IPs for the Scylla and Elasticsearch nodes.
 If you are running Elasticsearch on the same node as the python scripts, no need to enter IP, default 127.0.0.1 will be used.
 
-Use the -n flag to select the query type. The optional values are:
+Use the ```-n``` flag to select the query type, the optional values are:
 	- **single**: using a single filter (by group) to query for *“pants”*
 	- **multiple (default)**: using multiple filters (by color and sub_group) to query for *"white softshell"*
 	- **none**: query without any filter = *match_all*

--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -64,7 +64,7 @@ curl http://127.0.0.1:9200/_cluster/health?pretty
 	- insert_data_into_scylla+elastic.py
 	- query_data_from_scylla+elastic.py
 
-5. Run the “insert_data” script. The script will perform the following:
+5. Run the *“insert_data”* script. The script will perform the following:
 	- Create the Schema on Scylla
 	- Create the Elasticsearch index
 	- Dual write: insert the catalog items (csv file) to both DBs (using prepared statement for Scylla)
@@ -82,7 +82,7 @@ $ python insert_data_into_scylla+elastic.py -h
 	  -e ES_IP
 ```
 
-6. Once the “insert_data” script completes, you will find 160 entries in both Scylla and Elasticsearch
+6. Once the *“insert_data”* script completes, you will find 160 entries in both Scylla and Elasticsearch
 ```
 $ curl http://127.0.0.1:9200/catalog/_count/?pretty
 {
@@ -113,11 +113,11 @@ Use the ```-s | -e``` flags to insert a comma-separated list of IPs for the Scyl
 If you are running Elasticsearch on the same node as the python scripts, no need to enter IP, default 127.0.0.1 will be used.
 
 Use the ```-n``` flag to select the query type, the optional values are:
-	- **single**: using a single filter (by group) to query for *“pants”*
-	- **multiple (default)**: using multiple filters (by color and sub_group) to query for *"white softshell"*
-	- **none**: query without any filter = *match_all*
+- **single**: using a single filter (by group) to query for *“pants”*
+- **multiple (default)**: using multiple filters (by color and sub_group) to query for *"white softshell"*
+- **none**: query without any filter = *match_all*
 
-Note: Elasticsearch returns only the 1st 10 results by default. To overcome this we set the size limit to 1000 results. For large result we recommend using pagination (read more here: [elasticsearch-py helpers](http://elasticsearch-py.readthedocs.io/en/master/helpers.html?highlight=scroll)).
+**Note:** Elasticsearch returns only the 1st 10 results by default. To overcome this we set the size limit to 1000 results. For large result we recommend using pagination (read more here: [elasticsearch-py helpers](http://elasticsearch-py.readthedocs.io/en/master/helpers.html?highlight=scroll)).
 
 ```
 $ python query_data_from_scylla+elastic.py -h

--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -7,7 +7,7 @@ We will be using two python scripts to demonstrate the integration of Scylla wit
 2.  Textual search using the “query_data” script, a 2-hop query that will retrieve the unique product_id (SKU) from Elasticsearch and then use the SKU to retrieve all the other product attributes from Scylla.
 
 
-**Pre-requisites**
+**Prerequisites**
 - [python installed](https://www.python.org/download/releases/2.7/)
 - [pip installed](https://packaging.python.org/guides/installing-using-linux-tools/)
 - [Java 8 installed](http://openjdk.java.net/install/)

--- a/scylla_elasticsearch_integration/README.md
+++ b/scylla_elasticsearch_integration/README.md
@@ -3,8 +3,8 @@ General Info and Prerequisites
 
 The following example creates an apparel catalog stored on Scylla, and searchable using Elasticsearch (ES).      
 We will be using two python scripts to demonstrate the integration of Scylla with Elasticsearch.
-- Dual writes using the “insert_data” script for data ingestion, in our case an apparel catalog csv file.
-- Textual search using the “query_data” script, a 2-hop query that will retrieve the unique product_id (SKU) from Elasticsearch and then use the SKU to retrieve all the other product attributes from Scylla.
+1. Dual writes using the “insert_data” script for data ingestion, in our case an apparel catalog csv file.
+2.  Textual search using the “query_data” script, a 2-hop query that will retrieve the unique product_id (SKU) from Elasticsearch and then use the SKU to retrieve all the other product attributes from Scylla.
 
 
 **Pre-requisites**

--- a/scylla_elasticsearch_integration/catalog.csv
+++ b/scylla_elasticsearch_integration/catalog.csv
@@ -1,0 +1,161 @@
+SKU,brand,group,sub_group,color,size,gender
+nf-shr-ss-bk-s-m,North face,Shirts,short sleeve,black,Small,men
+pg-shr-ls-rd-m-m,Patagonia,Shirts,long sleeve,red,Medium,men
+mt-shr-uv-gy-l-m,Mammut,Shirts,UV_protection,grey,Large,men
+gm-shr-ls-gr-xl-m,Garmont,Shirts,long sleeve,green,XLarge,men
+cl-shr-ss-yw-s-n,Columbia,Shirts,short sleeve,yellow,Small,men
+nf-shr-ls-bl-m-m,North face,Shirts,long sleeve,blue,Medium,men
+pg-shr-ss-bk-l-m,Patagonia,Shirts,short sleeve,black,Large,men
+mt-shr-ls-rd-xl-m,Mammut,Shirts,long sleeve,red,XLarge,men
+gm-shr-uv-gy-s-m,Garmont,Shirts,UV_protection,grey,Small,men
+cl-shr-ls-gr-m-m,Columbia,Shirts,long sleeve,green,Medium,men
+nf-pan-hi-yw-l-m,North face,Pants,hiking,yellow,Large,men
+pg-pan-je-bl-xl-m,Patagonia,Pants,jeans,blue,XLarge,men
+mt-pan-hi-bk-s-m,Mammut,Pants,hiking,black,Small,men
+gm-pan-br-rd-m-m,Garmont,Pants,bermuda,red,Medium,men
+cl-pan-hi-gy-l-m,Columbia,Pants,hiking,grey,Large,men
+nf-pan-br-gr-xl-m,North face,Pants,bermuda,green,XLarge,men
+pg-pan-hi-yw-s-m,Patagonia,Pants,hiking,yellow,Small,men
+mt-pan-je-bl-m-m,Mammut,Pants,jeans,blue,Medium,men
+gm-pan-hi-bk-l-m,Garmont,Pants,hiking,black,Large,men
+cl-pan-br-rd-xl-m,Columbia,Pants,bermuda,red,XLarge,men
+nf-sho-gt-gy-s-m,North face,Shoes,gore-tex,grey,Small,men
+pg-sho-lt-gr-m-m,Patagonia,Shoes,leather,green,Medium,men
+mt-sho-gt-yw-l-m,Mammut,Shoes,gore-tex,yellow,Large,men
+gm-sho-lt-bl-xl-m,Garmont,Shoes,leather,blue,XLarge,men
+cl-sho-gt-bk-s-m,Columbia,Shoes,gore-tex,black,Small,men
+nf-sho-lt-rd-m-m,North face,Shoes,leather,red,Medium,men
+pg-sho-gt-gy-l-m,Patagonia,Shoes,gore-tex,grey,Large,men
+mt-sho-lt-gr-xl-m,Mammut,Shoes,leather,green,XLarge,men
+gm-sho-gt-yw-s-m,Garmont,Shoes,gore-tex,yellow,Small,men
+cl-sho-lt-bl-m-m,Columbia,Shoes,leather,blue,Medium,men
+nf-jac-lt-bk-l-m,North face,Jackets,leather,black,Large,men
+pg-jac-sf-rd-xl-m,Patagonia,Jackets,softshell,red,XLarge,men
+mt-jac-lt-gy-s-m,Mammut,Jackets,leather,grey,Small,men
+gm-jac-sf-gr-m-m,Garmont,Jackets,softshell,green,Medium,men
+cl-jac-lt-yw-l-m,Columbia,Jackets,leather,yellow,Large,men
+nf-jac-sf-bl-xl-m,North face,Jackets,softshell,blue,XLarge,men
+pg-jac-lt-wh-s-m,Patagonia,Jackets,leather,white,Small,men
+mt-jac-sf-wh-m-m,Mammut,Jackets,softshell,white,Medium,men
+gm-jac-lt-wh-l-m,Garmont,Jackets,leather,white,Large,men
+cl-jac-sf-wh-xl-m,Columbia,Jackets,softshell,white,XLarge,men
+nf-shr-ss-bk-s-w,North face,Shirts,short sleeve,Black,Small,women
+pg-shr-ls-rd-m-w,Patagonia,Shirts,long sleeve,red,Medium,women
+mt-shr-uv-gy-l-w,Mammut,Shirts,UV_protection,grey,Large,women
+gm-shr-ls-gr-xl-w,Garmont,Shirts,long sleeve,green,XLarge,women
+cl-shr-ss-yw-s-w,Columbia,Shirts,short sleeve,yellow,Small,women
+nf-shr-ls-bl-m-w,North face,Shirts,long sleeve,blue,Medium,women
+pg-shr-ss-bk-l-w,Patagonia,Shirts,short sleeve,black,Large,women
+mt-shr-ls-rd-xl-w,Mammut,Shirts,long sleeve,red,XLarge,women
+gm-shr-uv-gy-s-w,Garmont,Shirts,UV_protection,grey,Small,women
+cl-shr-ls-gr-m-w,Columbia,Shirts,long sleeve,green,Medium,women
+nf-pan-hi-yw-l-w,North face,Pants,hiking,yellow,Large,women
+pg-pan-je-bl-xl-w,Patagonia,Pants,jeans,blue,XLarge,women
+mt-pan-hi-bk-s-w,Mammut,Pants,hiking,black,Small,women
+gm-pan-je-rd-m-w,Garmont,Pants,jeans,red,Medium,women
+cl-pan-hi-gy-l-w,Columbia,Pants,hiking,grey,Large,women
+nf-pan-je-gr-xl-w,North face,Pants,jeans,green,XLarge,women
+pg-pan-hi-yw-s-w,Patagonia,Pants,hiking,yellow,Small,women
+mt-pan-je-bl-m-w,Mammut,Pants,jeans,blue,Medium,women
+gm-pan-hi-bk-l-w,Garmont,Pants,hiking,black,Large,women
+cl-pan-je-rd-xl-w,Columbia,Pants,jeans,red,XLarge,women
+nf-sho-gt-gy-s-w,North face,Shoes,gore-tex,grey,Small,women
+pg-sho-lt-gr-m-w,Patagonia,Shoes,leather,green,Medium,women
+mt-sho-gt-yw-l-w,Mammut,Shoes,gore-tex,yellow,Large,women
+gm-sho-lt-bl-xl-w,Garmont,Shoes,leather,blue,XLarge,women
+cl-sho-gt-bk-s-w,Columbia,Shoes,gore-tex,black,Small,women
+nf-sho-lt-rd-m-w,North face,Shoes,leather,red,Medium,women
+pg-sho-gt-gy-l-w,Patagonia,Shoes,gore-tex,grey,Large,women
+mt-sho-lt-gr-xl-w,Mammut,Shoes,leather,green,XLarge,women
+gm-sho-gt-yw-s-w,Garmont,Shoes,gore-tex,yellow,Small,women
+cl-sho-lt-bl-m-w,Columbia,Shoes,leather,blue,Medium,women
+nf-jac-lt-bk-l-w,North face,Jackets,leather,black,Large,women
+pg-jac-sf-rd-xl-w,Patagonia,Jackets,softshell,red,XLarge,women
+mt-jac-lt-gy-s-w,Mammut,Jackets,leather,grey,Small,women
+gm-jac-sf-gr-m-w,Garmont,Jackets,softshell,green,Medium,women
+cl-jac-lt-yw-l-w,Columbia,Jackets,leather,yellow,Large,women
+nf-jac-sf-bl-xl-w,North face,Jackets,softshell,blue,XLarge,women
+pg-jac-lt-wh-s-w,Patagonia,Jackets,leather,white,Small,women
+mt-jac-sf-wh-m-w,Mammut,Jackets,softshell,white,Medium,women
+gm-jac-lt-wh-l-w,Garmont,Jackets,leather,white,Large,women
+cl-jac-sf-wh-xl-w,Columbia,Jackets,softshell,white,XLarge,women
+nf-shr-ss-bk-s-b,North face,Shirts,short sleeve,Black,Small,boys
+pg-shr-ls-rd-m-b,Patagonia,Shirts,long sleeve,red,Medium,boys
+mt-shr-uv-gy-l-b,Mammut,Shirts,UV_protection,grey,Large,boys
+gm-shr-ls-gr-xl-b,Garmont,Shirts,long sleeve,green,XLarge,boys
+cl-shr-ss-yw-s-b,Columbia,Shirts,short sleeve,yellow,Small,boys
+nf-shr-ls-bl-m-b,North face,Shirts,long sleeve,blue,Medium,boys
+pg-shr-ss-bk-l-b,Patagonia,Shirts,short sleeve,black,Large,boys
+mt-shr-ls-rd-xl-b,Mammut,Shirts,long sleeve,red,XLarge,boys
+gm-shr-uv-gy-s-b,Garmont,Shirts,UV_protection,grey,Small,boys
+cl-shr-ls-gr-m-b,Columbia,Shirts,long sleeve,green,Medium,boys
+nf-pan-hi-yw-l-b,North face,Pants,hiking,yellow,Large,boys
+pg-pan-je-bl-xl-b,Patagonia,Pants,jeans,blue,XLarge,boys
+mt-pan-hi-bk-s-b,Mammut,Pants,hiking,black,Small,boys
+gm-pan-je-rd-m-b,Garmont,Pants,jeans,red,Medium,boys
+cl-pan-hi-gy-l-b,Columbia,Pants,hiking,grey,Large,boys
+nf-pan-je-gr-xl-b,North face,Pants,jeans,green,XLarge,boys
+pg-pan-hi-yw-s-b,Patagonia,Pants,hiking,yellow,Small,boys
+mt-pan-je-bl-m-b,Mammut,Pants,jeans,blue,Medium,boys
+gm-pan-hi-bk-l-b,Garmont,Pants,hiking,black,Large,boys
+cl-pan-je-rd-xl-b,Columbia,Pants,jeans,red,XLarge,boys
+nf-sho-gt-gy-s-b,North face,Shoes,gore-tex,grey,Small,boys
+pg-sho-lt-gr-m-b,Patagonia,Shoes,leather,green,Medium,boys
+mt-sho-gt-yw-l-b,Mammut,Shoes,gore-tex,yellow,Large,boys
+gm-sho-lt-bl-xl-b,Garmont,Shoes,leather,blue,XLarge,boys
+cl-sho-gt-bk-s-b,Columbia,Shoes,gore-tex,black,Small,boys
+nf-sho-lt-rd-m-b,North face,Shoes,leather,red,Medium,boys
+pg-sho-gt-gy-l-b,Patagonia,Shoes,gore-tex,grey,Large,boys
+mt-sho-lt-gr-xl-b,Mammut,Shoes,leather,green,XLarge,boys
+gm-sho-gt-yw-s-b,Garmont,Shoes,gore-tex,yellow,Small,boys
+cl-sho-lt-bl-m-b,Columbia,Shoes,leather,blue,Medium,boys
+nf-jac-lt-bk-l-b,North face,Jackets,leather,black,Large,boys
+pg-jac-sf-rd-xl-b,Patagonia,Jackets,softshell,red,XLarge,boys
+mt-jac-lt-gy-s-b,Mammut,Jackets,leather,grey,Small,boys
+gm-jac-sf-gr-m-b,Garmont,Jackets,softshell,green,Medium,boys
+cl-jac-lt-yw-l-b,Columbia,Jackets,leather,yellow,Large,boys
+nf-jac-sf-bl-xl-b,North face,Jackets,softshell,blue,XLarge,boys
+pg-jac-lt-wh-s-b,Patagonia,Jackets,leather,white,Small,boys
+mt-jac-sf-wh-m-b,Mammut,Jackets,softshell,white,Medium,boys
+gm-jac-lt-wh-l-b,Garmont,Jackets,leather,white,Large,boys
+cl-jac-sf-wh-xl-b,Columbia,Jackets,softshell,white,XLarge,boys
+nf-shr-ss-bk-s-g,North face,Shirts,short sleeve,Black,Small,girls
+pg-shr-ls-rd-m-g,Patagonia,Shirts,long sleeve,red,Medium,girls
+mt-shr-uv-gy-l-g,Mammut,Shirts,UV_protection,grey,Large,girls
+gm-shr-ls-gr-xl-g,Garmont,Shirts,long sleeve,green,XLarge,girls
+cl-shr-ss-yw-s-g,Columbia,Shirts,short sleeve,yellow,Small,girls
+nf-shr-ls-bl-m-g,North face,Shirts,long sleeve,blue,Medium,girls
+pg-shr-ss-bk-l-g,Patagonia,Shirts,short sleeve,black,Large,girls
+mt-shr-ls-rd-xl-g,Mammut,Shirts,long sleeve,red,XLarge,girls
+gm-shr-uv-gy-s-g,Garmont,Shirts,UV_protection,grey,Small,girls
+cl-shr-ls-gr-m-g,Columbia,Shirts,long sleeve,green,Medium,girls
+nf-pan-hi-yw-l-g,North face,Pants,hiking,yellow,Large,girls
+pg-pan-je-bl-xl-g,Patagonia,Pants,jeans,blue,XLarge,girls
+mt-pan-hi-bk-s-g,Mammut,Pants,hiking,black,Small,girls
+gm-pan-je-rd-m-g,Garmont,Pants,jeans,red,Medium,girls
+cl-pan-hi-gy-l-g,Columbia,Pants,hiking,grey,Large,girls
+nf-pan-je-gr-xl-g,North face,Pants,jeans,green,XLarge,girls
+pg-pan-hi-yw-s-g,Patagonia,Pants,hiking,yellow,Small,girls
+mt-pan-je-bl-m-g,Mammut,Pants,jeans,blue,Medium,girls
+gm-pan-hi-bk-l-g,Garmont,Pants,hiking,black,Large,girls
+cl-pan-je-rd-xl-g,Columbia,Pants,jeans,red,XLarge,girls
+nf-sho-gt-gy-s-g,North face,Shoes,gore-tex,grey,Small,girls
+pg-sho-lt-gr-m-g,Patagonia,Shoes,leather,green,Medium,girls
+mt-sho-gt-yw-l-g,Mammut,Shoes,gore-tex,yellow,Large,girls
+gm-sho-lt-bl-xl-g,Garmont,Shoes,leather,blue,XLarge,girls
+cl-sho-gt-bk-s-g,Columbia,Shoes,gore-tex,black,Small,girls
+nf-sho-lt-rd-m-g,North face,Shoes,leather,red,Medium,girls
+pg-sho-gt-gy-l-g,Patagonia,Shoes,gore-tex,grey,Large,girls
+mt-sho-lt-gr-xl-g,Mammut,Shoes,leather,green,XLarge,girls
+gm-sho-gt-yw-s-g,Garmont,Shoes,gore-tex,yellow,Small,girls
+cl-sho-lt-bl-m-g,Columbia,Shoes,leather,blue,Medium,girls
+nf-jac-lt-bk-l-g,North face,Jackets,leather,black,Large,girls
+pg-jac-sf-rd-xl-g,Patagonia,Jackets,softshell,red,XLarge,girls
+mt-jac-lt-gy-s-g,Mammut,Jackets,leather,grey,Small,girls
+gm-jac-sf-gr-m-g,Garmont,Jackets,softshell,green,Medium,girls
+cl-jac-lt-yw-l-g,Columbia,Jackets,leather,yellow,Large,girls
+nf-jac-sf-bl-xl-g,North face,Jackets,softshell,blue,XLarge,girls
+pg-jac-lt-wh-s-g,Patagonia,Jackets,leather,white,Small,girls
+mt-jac-sf-wh-m-g,Mammut,Jackets,softshell,white,Medium,girls
+gm-jac-lt-wh-l-g,Garmont,Jackets,leather,white,Large,girls
+cl-jac-sf-wh-xl-g,Columbia,Jackets,softshell,white,XLarge,girls

--- a/scylla_elasticsearch_integration/insert_data_into_scylla+elastic.py
+++ b/scylla_elasticsearch_integration/insert_data_into_scylla+elastic.py
@@ -1,0 +1,101 @@
+#! /usr/bin/env python
+# -*- coding: latin-1 -*-
+#
+
+### Using elasticsearch-py ###
+import csv
+from cassandra.cluster import Cluster
+from elasticsearch import Elasticsearch
+
+import random
+import argparse
+import concurrent.futures
+from cassandra import ConsistencyLevel
+from cassandra.concurrent import execute_concurrent_with_args
+
+
+## Script args and Help
+parser = argparse.ArgumentParser(add_help=True)
+
+parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="127.0.0.1")
+parser.add_argument('-e', action="store", dest="ES_IP", default="127.0.0.1")
+
+opts = parser.parse_args()
+
+SCYLLA_IP = opts.SCYLLA_IP.split(',')
+ES_IP = opts.ES_IP.split(',')
+
+
+## Define KS + Table
+create_ks = "CREATE KEYSPACE IF NOT EXISTS catalog WITH replication = {'class' : 'SimpleStrategy', 'replication_factor' : 3};"
+create_t1 = "CREATE TABLE IF NOT EXISTS catalog.apparel (sku text, brand text, group text, sub_group text, color text, size text, gender text, PRIMARY KEY ((sku),color,size));"
+
+
+## Loading the data
+def load_data(filename):
+    data = []
+    headers = []
+    with open(filename, "r") as f:
+        reader = csv.reader(f)
+        headers = next(reader) # read the headers line
+
+        for l in reader:
+            doc = {}
+            for i in range(0, len(l)):
+                doc[headers[i].lower()] = l[i]
+
+            data.append(doc)
+
+    return headers, data
+
+
+## Insert the data
+def insert_data(headers, data):
+    ## Connect to Scylla cluster and create schema
+    # session = cassandra.cluster.Cluster(SCYLLA_IP).connect()
+    print("")
+    print("## Connecting to Scylla cluster -> Creating schema")
+    session = Cluster(SCYLLA_IP).connect()
+    session.execute(create_ks)
+    session.execute(create_t1)
+
+    ## Connect to Elasticsearch
+    print ("")
+    print ("## Connecting to Elasticsearch -> Creating 'Catalog' index")
+    es = Elasticsearch(ES_IP)
+    
+    ## Create Elasticsearch index. Ignore 400 = IF NOT EXIST
+    es.indices.create(index="catalog", ignore=400)
+
+    ## Non-prepared CQL statement
+    #cql = "INSERT INTO catalog.apparel(sku,brand,group,sub_group,color,size,gender) VALUES(%(sku)s,%(brand)s,%(group)s,%(sub_group)s,%(color)s,%(size)s,%(gender)s)"
+
+    ## Prepared CQL statement
+    print("")
+    print("## Preparing CQL statement")
+    cql = "INSERT INTO catalog.apparel (sku,brand,group,sub_group,color,size,gender) VALUES (?,?,?,?,?,?,?) using TIMESTAMP ?"
+    cql_prepared = session.prepare(cql)
+    cql_prepared.consistency_level = ConsistencyLevel.ONE if random.random() < 0.2 else ConsistencyLevel.QUORUM
+
+    print("")
+    print("## Insert csv content into Scylla and Elasticsearch")
+
+
+    for d in data: 
+        # See if we need to add code to wait for the ack. This should be synchronous.
+        # Also, might need to switch to prepared statements to set the consistency level for sync requests.
+        session.execute(cql_prepared, d)
+
+        res = es.index(index="catalog", doc_type="apparel", id=d["sku"], body=d)
+
+    ## After all the inserts, make a refresh, just in case
+    print("")
+    print("## Inserts completed, refreshing index")
+    es.indices.refresh(index="catalog")
+
+    print("")
+
+
+if __name__ == "__main__":
+    headers, data = load_data("./catalog.csv")
+    insert_data(headers, data)

--- a/scylla_elasticsearch_integration/query_data_from_scylla+elastic.py
+++ b/scylla_elasticsearch_integration/query_data_from_scylla+elastic.py
@@ -1,0 +1,97 @@
+#! /usr/bin/env python
+# -*- coding: latin-1 -*-
+#
+
+### Using elasticsearch-py ###
+from cassandra.cluster import Cluster
+from elasticsearch import Elasticsearch
+
+import random
+import argparse
+import concurrent.futures
+from cassandra import ConsistencyLevel
+from cassandra.concurrent import execute_concurrent_with_args
+
+
+## Script args and help
+parser = argparse.ArgumentParser(add_help=True)
+
+parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="127.0.0.1")
+parser.add_argument('-e', action="store", dest="ES_IP", default="127.0.0.1")
+parser.add_argument('-n', action="store", dest="NUM_FILTERS", default="multiple")
+
+opts = parser.parse_args()
+
+SCYLLA_IP = opts.SCYLLA_IP.split(',')
+ES_IP = opts.ES_IP.split(',')
+
+
+def query_es(NUM_FILTERS):
+
+    ## Connect to Elasticsearch
+    print("")
+    print("## Connecting to Elasticsearch")
+    es = Elasticsearch(ES_IP)
+
+    if NUM_FILTERS == 'single':
+        ## Search using single field filter (group: 'pants')
+        print("")
+        print("## Searching for 'pants' in Elasticsearch (filter by group)")
+        res = es.search(index="catalog", doc_type="apparel", body={"query": {"match": {"group": "pants"}}, "size": 1000})
+
+    if NUM_FILTERS == 'multiple':
+        ## Search using multiple fields filter (color: 'white' AND sub_group: 'softshell')
+        print("")
+        print("## Searching for 'white softshell' in Elasticsearch (filter by color + sub_group)")
+        res = es.search(index="catalog", doc_type="apparel", body={"query": {"bool": {"must": [{"match": {"color": "white"}}, {"match": {"sub_group": "softshell"}}]}}, "size": 1000})
+
+    if NUM_FILTERS == 'none':
+        ## Search with NO filters (match_all)
+        print("")
+        print("## Searching with NO filter = 'match_all' in Elasticsearch")
+        res = es.search(index="catalog", doc_type="apparel", body={"query": {"match_all": {}}, "size": "1000"})
+
+    print("")
+    print("## %d documents returned" % res['hits']['total'])
+
+    es_results = [doc['_id'] for doc in res['hits']['hits']]
+
+    ## Connect to Scylla
+    print("")
+    print("## Connecting to Scylla")
+    session = Cluster(SCYLLA_IP).connect()
+
+
+    ## Prepared cql statement
+    print("")
+    print("## Preparing CQL statement")
+    cql = "SELECT * FROM catalog.apparel WHERE sku=?"
+    cql_prepared = session.prepare(cql)
+    cql_prepared.consistency_level = ConsistencyLevel.ONE if random.random() < 0.2 else ConsistencyLevel.QUORUM
+
+
+    ## Query Scylla
+    print("")
+    print("## Query Scylla using SKU/s returned from Elasticsearch")
+
+    print("")
+    print("## Final results from Scylla:")
+    print("")
+    for r in es_results:
+        scylla_res = session.execute(cql_prepared, (r,))
+        print("%s" % ([list(row) for row in scylla_res]))
+
+
+    #for doc in res['hits']['hits']:
+
+        ## Print all columns in Elasticsearch result set
+        #print("SKU: %s | Color: %s | Size: %s | Brand: %s | Gender: %s | Group: %s | Sub_Group: %s" % (doc['_id'], doc['_source']['color'], doc['_source']['size'], doc['_source']['brand'], doc['_source']['gender'], doc['_source']['group'], doc['_source']['sub_group']))
+
+        ## Print only the id (sku) in the result set
+        #print("SKU: %s" % (doc['_id']))
+
+    print("")
+
+if __name__ == '__main__':
+    query_es(opts.NUM_FILTERS)
+


### PR DESCRIPTION
Scylla-Elasticsearch integration: code example for insert (dual writes) + 2-hop query (fetch product_id from Elasticsearch and use it to fetch all product attributes from Scylla