### PR TITLE
efficient_full_table_scan: Use the correct path for the rows file

### DIFF
--- a/efficient_full_table_scan_example_code/efficient_full_table_scan.go
+++ b/efficient_full_table_scan_example_code/efficient_full_table_scan.go
@@ -186,7 +186,7 @@ Print Rows Output File        : %s
 		// List of returned values from the queries
 		printOutChannel = make(chan int64)
 		go func() {
-			if f, err := os.Create("/tmp/rows.txt"); err == nil {
+			if f, err := os.Create(*printRowsOutputFile); err == nil {
 				defer f.Close()
 
 				for tokenKey := range printOutChannel {


### PR DESCRIPTION
The script was ignoring --print-rows-output-file switch, and also was
showing wrong default path for the file.