### PR TITLE
efficient_full_table_scans: allow the usage of username and passwords

### DIFF
--- a/efficient_full_table_scan_example_code/README.md
+++ b/efficient_full_table_scan_example_code/README.md
@@ -56,6 +56,8 @@ Flags:
   -d, --print-rows              Print the output rows to a file
       --print-rows-output-file="/tmp/rows.txt"
                                 Output file that will contain the printed rows
+      --username                The username to use to connect to the cluster (default: no username)
+      --password                The password to use to connect to the cluster (default: no password)
 
 Args:
   <hosts>  Your Scylla nodes IP addresses, comma separated (i.e. 192.168.1.1,192.168.1.2,192.168.1.3)

--- a/efficient_full_table_scan_example_code/efficient_full_table_scan.go
+++ b/efficient_full_table_scan_example_code/efficient_full_table_scan.go
@@ -43,6 +43,9 @@ var (
 	printRows           = kingpin.Flag("print-rows", "Print the output rows to a file").Short('d').Default("false").Bool()
 	printRowsOutputFile = kingpin.Flag("print-rows-output-file", "Output file that will contain the printed rows").Default(defaultPrintRowsOutputFile).String()
 
+	userName            = kingpin.Flag("username", "Username to use when connecting to the cluster").String()
+	password            = kingpin.Flag("password", "Password to use when connecting to the cluster").String()
+
 	numberOfParallelClientThreads = 1 // the calculated number of parallel threads the client should run
 
 )
@@ -137,6 +140,13 @@ func main() {
 	cluster.NumConns = *clusterNumConnections
 	cluster.CQLVersion = *clusterCQLVersion
 	cluster.PageSize = *clusterPageSize
+
+	if (*userName != "") {
+		cluster.Authenticator = gocql.PasswordAuthenticator{
+			Username: *userName,
+			Password: *password,
+		}
+	}
 
 	runParameters := fmt.Sprintf(`
 Execution Parameters:


### PR DESCRIPTION
Because -p is taken I am not providing a short form for --password. And then
for consistency I am not providing a short for for --username either.

Signed-off-by: Glauber Costa <glauber@scylladb.com>