### PR TITLE
Add hostNetwork support to chart

### DIFF
--- a/helm-chart-scylla/README.md
+++ b/helm-chart-scylla/README.md
@@ -113,3 +113,33 @@ A good introduction to Helm Charts by Amy Chen can be found [here](https://youtu
   * Delete your helm release
     
     `helm delete <releaseName>`
+
+
+## Configuration
+
+The following table lists the configurable parameters of the ScyllaDB chart and their default valuessdsdsd.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`config.cpu` | Restricts Scylla to N logical cores (numeric) | `nil`
+`config.overprovisioned` | If true, Scylla that the machine it is running on is used by other processes | `true`
+`image.repository` | Container image repository | `scylladb/scylla`
+`image.tag` | Container image tag | `2.1.3`
+`image.pullPolicy` | Container image pull policy | `IfNotPresent`
+`persistence.accessMode` | Persistent Volume access modes  | `ReadWriteOnce`
+`persistence.size` | Persistent Volume size | `15Gi`
+`persistence.storageClass` | Persistent Volume Storage Class | `scylla-ssd`
+`replicaCount` | Number of replicas in the StatefulSet | `3`
+`resources` | ScyllaDB StatefulSet pod resource requests & limits | `{}`
+`service.cqlPort` | CQL port | `9042`
+`service.internodePort` | Inter-node communication port | `7000`
+`service.sslinternodePort` | SSL inter-node communication port | `7001`
+`service.jmxPort` | JMX management port | `7199`
+`service.restPort` | Scylla REST API port | `10000`
+`service.prometheusPort` | Prometheus API port | `9180`
+`service.nodeExporterPort` | node_exporter port | `9100`
+`service.thriftPort` | Scylla client (Thrift) port | `9160`
+`statefulset.hostNetwork` | If true, ScyllaDB pods share the host network namespace | `false`
+`nodeSelector` | Node labels for ScyllaDB pod assignment | `{}`
+`tolerations` | Node taints to tolerate (requires Kubernetes >=1.6) | `[]`
+`affinity` | Pod affinity | `{}`

--- a/helm-chart-scylla/templates/statefulset.yaml
+++ b/helm-chart-scylla/templates/statefulset.yaml
@@ -50,7 +50,6 @@ spec:
           - {{ template "scylladb.fullname" . }}-0.{{ template "scylladb.fullname" . }}.default.svc.cluster.local
           {{- if .Values.config.overprovisioned }}
           - --overprovisioned
-          - {{ .Values.config.overprovisioned | quote }}
           {{- end }}
           {{- if .Values.config.cpu }}
           - --smp

--- a/helm-chart-scylla/templates/statefulset.yaml
+++ b/helm-chart-scylla/templates/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
         app: {{ template "scylladb.name" . }}
         release: {{ .Release.Name }}
     spec:
+      hostNetwork: {{ .Values.statefulset.hostNetwork }}
       terminationGracePeriodSeconds: 120
       containers:
       - name: {{ template "scylladb.fullname" . }}

--- a/helm-chart-scylla/values.yaml
+++ b/helm-chart-scylla/values.yaml
@@ -22,7 +22,10 @@ service:
   nodeExporterPort: 9100
   thriftPort: 9160
   # Check http://docs.scylladb.com/admin/
-  
+
+statefulset:
+  hostNetwork: false
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/helm-chart-scylla/values.yaml
+++ b/helm-chart-scylla/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: IfNotPresent
 
 config:
-  overprovisioned: 1
+  overprovisioned: true
 
 service:
   cqlPort: 9042


### PR DESCRIPTION
In order to bypass Docker's networking layer, Kubernetes supports the `hostNetwork: true` option.
This PR adds support for this option (disabled by default) to the Helm chart.
Additionally, fixed a mistake where `--overprovisioned` was passed an argument (whereas it should be true/false).
Also added a configuration settings table to the README.