### PR TITLE
Bump Zeppelin version in mms/zeppelin to 0.8.1

### DIFF
--- a/mms/zeppelin/Dockerfile
+++ b/mms/zeppelin/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 WORKDIR /opt
 RUN apk update;apk add shadow py-pip less bash openjdk8-jre-base tar wget
-RUN wget -q -O zeppelin.tar.gz http://apache.claz.org/zeppelin/zeppelin-0.7.3/zeppelin-0.7.3-bin-all.tgz
+RUN wget -q -O zeppelin.tar.gz http://apache.claz.org/zeppelin/zeppelin-0.8.1/zeppelin-0.8.1-bin-all.tgz
 RUN tar xf zeppelin.tar.gz
 ADD interpreter.json /opt/zeppelin-0.7.3-bin-all/conf/
 CMD ./zepp*/bin/zeppelin-daemon.sh start;tail -f /dev/null


### PR DESCRIPTION
The old version, 0.7.3 is not available at this address anymore.