### PR TITLE
Updated PR for scylla-check-gossiper-generation

### DIFF
--- a/scylla-check-gossiper-generation/README.md
+++ b/scylla-check-gossiper-generation/README.md
@@ -2,6 +2,8 @@
 
 This is a checker required to run before upgrades on all long-running nodes. 
 
+*NOTE*: This script must be run on every node, it only checks the single current node, not the entire cluster. 
+
 ### Usage:
 
 On an operational Scylla node, with working `nodetool` available run

--- a/scylla-check-gossiper-generation/README.md
+++ b/scylla-check-gossiper-generation/README.md
@@ -1,0 +1,11 @@
+# scylla-check-gossiper-generation
+
+This is a checker required to run before upgrades on all long-running nodes. 
+
+### Usage:
+
+On an operational Scylla node, with working `nodetool` available run
+
+`./scylla-check-gossiper-generation.sh`
+
+The output will advise on whether the user should get in touch with Scylla support before proceeding with an upgrade. 

--- a/scylla-check-gossiper-generation/scylla-check-gossiper-generation.sh
+++ b/scylla-check-gossiper-generation/scylla-check-gossiper-generation.sh
@@ -5,7 +5,26 @@
 
 set -e
 
-GEN=`nodetool gossipinfo | grep 'generation:'|awk -F':' '{ print $2 }'`
+# Check for varying broadcast address and listen address settings
+LISTN=`grep 'listen_address:' /etc/scylla/scylla.yaml|awk -F':' '{ print $2 }' | xargs`
+BCAST=`grep 'broadcast_address:' /etc/scylla/scylla.yaml`
+if [[ "$BCAST" =~ ^#.* ]]; then #if broadcast address is commented out, use listen address
+    IP="$LISTN"
+else
+    BCAST=`grep 'broadcast_address:' /etc/scylla/scylla.yaml|awk -F':' '{ print $2 }' | xargs`
+fi
+if [[ "$LISTN" == "$BCAST" ]]; then #if broadcast address differs from listen address, use broadcast
+    IP="$LISTN"
+else
+    IP="$BCAST"
+fi
+
+#Get gossip generation only for current node
+GEN=`nodetool gossipinfo | grep -A1 "$IP" | grep 'generation:' | awk -F':' '{ print $2 }' | xargs`
+if [[ ! "$GEN" =~ ^[1-9]+[0-9]*$ ]]; then
+    printf "Faulty output from nodetool, please try again or contact Scylla support"
+    exit 1
+fi
 NOW=`date +%s`
 DIF=$(( $NOW - $GEN ))
 YEAR=31536000 #seconds = 365 * 24 * 60 * 60

--- a/scylla-check-gossiper-generation/scylla-check-gossiper-generation.sh
+++ b/scylla-check-gossiper-generation/scylla-check-gossiper-generation.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This script checks the node's gossiper generation and produces an alert if it is older 
+# than 1 year.
+
+set -e
+
+GEN=`nodetool gossipinfo | grep 'generation:'|awk -F':' '{ print $2 }'`
+NOW=`date +%s`
+DIF=$(( $NOW - $GEN ))
+YEAR=31536000 #seconds = 365 * 24 * 60 * 60
+
+if [[ $DIF -gt $YEAR ]]; then 
+    printf "Gossiper generation older than 1 year, please refrain from restarting Scylla service or node reboot.\nPlease contact Scylla support for next steps, prior to upgrade.\n"
+else
+    printf "Gossiper generation is below 1 year, it should be safe to upgrade.\n"
+fi


### PR DESCRIPTION
Adding support for:

- Larger clusters (previously tested on single nodes only) 
- Various combinations of listen_address and broadcast_address settings
- Faulty outputs from nodetool
- Extra clarification in README