### PR TITLE
repleacement old netty jar link

### DIFF
--- a/mms/java/Dockerfile
+++ b/mms/java/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 RUN apk update;apk add shadow bash openjdk8 apache-ant wget unzip
 WORKDIR /opt/code/libs
-RUN wget -q https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-all/4.0.56.Final-SNAPSHOT/netty-all-4.0.56.Final-20180202.121251-12.jar
+RUN wget -q https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-all/4.0.57.Final-SNAPSHOT/netty-all-4.0.57.Final-20181019.121534-257.jar
 RUN wget -q http://downloads.datastax.com/java-driver/cassandra-java-driver-3.5.0.tar.gz;tar xf cassandra-java-driver-3.5.0.tar.gz
 RUN mv cassandra-java-driver-3.5.0/*.jar .;mv cassandra-java-driver-3.5.0/lib/* .
 WORKDIR /opt/code

--- a/mms/java/Dockerfile
+++ b/mms/java/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 RUN apk update;apk add shadow bash openjdk8 apache-ant wget unzip
 WORKDIR /opt/code/libs
-RUN wget -q https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-all/4.0.57.Final-SNAPSHOT/netty-all-4.0.57.Final-20181019.121534-257.jar
+RUN wget -q https://repo1.maven.org/maven2/io/netty/netty-all/4.1.70.Final/netty-all-4.1.70.Final.jar
 RUN wget -q http://downloads.datastax.com/java-driver/cassandra-java-driver-3.5.0.tar.gz;tar xf cassandra-java-driver-3.5.0.tar.gz
 RUN mv cassandra-java-driver-3.5.0/*.jar .;mv cassandra-java-driver-3.5.0/lib/* .
 WORKDIR /opt/code


### PR DESCRIPTION
The old path for netty repository is not exist anymore -->

404 - Path /io/netty/netty-all/4.0.56.Final-SNAPSHOT/netty-all-4.0.56.Final-20180202.121251-12.jar not found in local storage of repository "Snapshots" [id=snapshots]

replaced to: 
https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-all/4.0.57.Final-SNAPSHOT/netty-all-4.0.57.Final-20181019.121534-257.jar
