### PR TITLE
changed repo for netty-all

### DIFF
--- a/mms/java/Dockerfile
+++ b/mms/java/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 RUN apk update;apk add shadow bash openjdk8 apache-ant wget unzip
 WORKDIR /opt/code/libs
-RUN wget -q https://oss.sonatype.org/content/repositories/snapshots/io/netty/netty-all/4.0.56.Final-SNAPSHOT/netty-all-4.0.56.Final-20180202.121251-12.jar
+RUN wget -q https://repo1.maven.org/maven2/io/netty/netty-all/4.0.56.Final/netty-all-4.0.56.Final.jar
 RUN wget -q http://downloads.datastax.com/java-driver/cassandra-java-driver-3.5.0.tar.gz;tar xf cassandra-java-driver-3.5.0.tar.gz
 RUN mv cassandra-java-driver-3.5.0/*.jar .;mv cassandra-java-driver-3.5.0/lib/* .
 WORKDIR /opt/code


### PR DESCRIPTION
The previous location for the netty-all jar was no longer broken which broke the examples. This updates the repo location to maven.org
@nukemberg please review, you can run a lesson that uses this for example this one: https://university.scylladb.com/courses/using-scylla-drivers/lessons/coding-with-java-part-3/