### PR TITLE
add presto in docker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ buildNumber.properties
 *iml
 *.jar
 *.csv
+presto/resources/etc/node.properties
+presto/.docker

--- a/presto/README.md
+++ b/presto/README.md
@@ -1,0 +1,27 @@
+# Presto in Docker with Jaeger and Metabase
+
+This sample contains a docker-compose.yml and Presto configs for running Presto in Docker with Jaeger, Metabase and ScyllaDB.
+
+The following example uses Jaeger HotRod sample application as data producer which sends traces to Jaeger collector. 
+Jaeger collector stores traces in ScyllaDB. Presto is used to query traces from ScyllaDB and 
+Metabase is used to visualize the data.
+
+**Prerequisites**
+- [docker installed](https://docs.docker.com/engine/install/)
+
+Instructions
+============
+
+**Procedure**
+1. Run `docker-compose up -d` to start the containers
+2. Wait for about minute for ScyllaDB to start and Metabase to initialize.
+3. Open Jaeger HotRod sample application at http://localhost:8081 and click on buttons to generate traces.
+4. Open Metabase at http://localhost:3000 and complete admin onboarding.
+5. Add Presto as a data source in Metabase. 
+Use `http://presto:8080` as a host and `scylladb` as a catalog name. 
+During filling presto connection details fill `Username` with arbitrary string 
+and leave user `Password` empty.
+6. Observe traces insights in Metabase.
+
+**Cleanup**
+1. Run `docker-compose down --volumes` to stop and remove the containers and created volumes

--- a/presto/README.md
+++ b/presto/README.md
@@ -18,10 +18,19 @@ Instructions
 3. Open Jaeger HotRod sample application at http://localhost:8081 and click on buttons to generate traces.
 4. Open Metabase at http://localhost:3000 and complete admin onboarding.
 5. Add Presto as a data source in Metabase. 
-Use `http://presto:8080` as a host and `scylladb` as a catalog name. 
+Use `presto` as a host, `8080` as a port and `scylladb` as a catalog name. 
 During filling presto connection details fill `Username` with arbitrary string 
 and leave user `Password` empty.
-6. Observe traces insights in Metabase.
+6. Observe traces insights in Metabase. For example from home screen do:
+    * Click on "Browse data" button
+    * Choose created Presto data source
+    * Select jaeger_v1_test schema
+    * Open Operation Names V2 table
+    * On the right top Click green "Summarize" button
+    * Select Group By "Service Name"
+    * On the left bottom size click "Visualization" button
+    * Choose "Pie" visualization
+    * Save "Question" as "Spans by Service Name"
 
 **Cleanup**
 1. Run `docker-compose down --volumes` to stop and remove the containers and created volumes

--- a/presto/docker-compose.yml
+++ b/presto/docker-compose.yml
@@ -1,0 +1,97 @@
+version: "3"
+
+networks:
+  presto:
+    driver: bridge
+
+services:
+  metabase:
+    restart: always
+    image: metabase/metabase:v0.43.7.3
+    platform: linux/amd64
+    ports:
+      - 3000:3000
+    networks:
+      - presto
+    volumes:
+      - .docker/metabase/data:/metabase-data
+    depends_on:
+      - presto
+
+  presto:
+    restart: always
+    image: ahanaio/prestodb:0.282
+    platform: linux/amd64
+    ports:
+      - 8080:8080
+    networks:
+      - presto
+    volumes:
+      - ./resources/etc:/opt/presto-server/etc
+    depends_on:
+      - scylladb
+
+  scylladb:
+    restart: always
+    image: scylladb/scylla:5.1.7
+    ports:
+      - 9042:9042
+    volumes:
+      - .docker/scylladb/1:/var/lib/scylla
+    networks:
+      - presto
+    healthcheck:
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      interval: 1s
+      retries: 120
+      timeout: 1s
+
+  collector:
+    restart: always
+    image: jaegertracing/jaeger-collector:1.43
+    environment:
+      SPAN_STORAGE_TYPE: cassandra
+      CASSANDRA_SERVERS: scylladb
+      CASSANDRA_KEYSPACE: jaeger_v1_test
+    networks:
+      - presto
+    depends_on:
+      - scylladb
+
+  web:
+    image: jaegertracing/jaeger-query:1.43
+    restart: unless-stopped
+    ports:
+      - 16686:16686
+      - 16687:16687
+    environment:
+      SPAN_STORAGE_TYPE: cassandra
+      CASSANDRA_SERVERS: scylladb
+      CASSANDRA_KEYSPACE: jaeger_v1_test
+    networks:
+      - presto
+    depends_on:
+      - scylladb
+
+  cassandra-schema:
+    image: jaegertracing/jaeger-cassandra-schema:1.43
+    environment:
+      CQLSH_HOST: scylladb
+      DATACENTER: test
+      MODE: test
+    networks:
+      - presto
+    depends_on:
+      - scylladb
+
+  hotrod:
+    image: jaegertracing/example-hotrod:1.43
+    ports:
+      - 8081:8080
+    command: [ "all" ]
+    environment:
+      - OTEL_EXPORTER_JAEGER_ENDPOINT=http://collector:14268/api/traces
+    networks:
+      - presto
+    depends_on:
+      - collector

--- a/presto/resources/etc/catalog/scylladb.properties
+++ b/presto/resources/etc/catalog/scylladb.properties
@@ -1,0 +1,2 @@
+connector.name=cassandra
+cassandra.contact-points=scylladb

--- a/presto/resources/etc/config.properties
+++ b/presto/resources/etc/config.properties
@@ -1,0 +1,9 @@
+coordinator=true
+node-scheduler.include-coordinator=true
+http-server.http.port=8080
+node.environment=production
+node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
+query.max-memory=5GB
+query.max-memory-per-node=1GB
+discovery-server.enabled=true
+discovery.uri=http://presto:8080

--- a/presto/resources/etc/jvm.config
+++ b/presto/resources/etc/jvm.config
@@ -1,0 +1,9 @@
+-server
+-Xmx16G
+-XX:+UseG1GC
+-XX:G1HeapRegionSize=32M
+-XX:+UseGCOverheadLimit
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:+ExitOnOutOfMemoryError
+-Djdk.attach.allowAttachSelf=true

--- a/presto/resources/etc/log.properties
+++ b/presto/resources/etc/log.properties
@@ -1,0 +1,1 @@
+com.facebook.presto=INFO


### PR DESCRIPTION
this example runs jaeger server as data producer, scylladb, presto and metabase. All in single docker compose.