### PR TITLE
updating gocqlx to v2

### DIFF
--- a/mms/go/cmd/gocqlxapp/main.go
+++ b/mms/go/cmd/gocqlxapp/main.go
@@ -5,9 +5,9 @@ import (
 	"goapp/internal/scylla"
 
 	"github.com/gocql/gocql"
-	"github.com/scylladb/gocqlx"
-	"github.com/scylladb/gocqlx/qb"
-	"github.com/scylladb/gocqlx/table"
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/gocqlx/v2/qb"
+	"github.com/scylladb/gocqlx/v2/table"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Updating code example for lesson [Golang and ScyllaDB Part 3 – GoCQLX](https://university.scylladb.com/courses/using-scylla-drivers/lessons/golang-and-scylla-part-3-gocqlx/).
