### PR TITLE
refactor: ScyllaDB/Elasticsearch Query & Insertion script

### DIFF
--- a/scylla_elasticsearch_integration/insert_data_into_scylla+elastic.py
+++ b/scylla_elasticsearch_integration/insert_data_into_scylla+elastic.py
@@ -5,97 +5,91 @@
 ### Using elasticsearch-py ###
 import csv
 from cassandra.cluster import Cluster
+from cassandra import ConsistencyLevel
 from elasticsearch import Elasticsearch
 
 import random
 import argparse
-import concurrent.futures
-from cassandra import ConsistencyLevel
-from cassandra.concurrent import execute_concurrent_with_args
-
 
 ## Script args and Help
 parser = argparse.ArgumentParser(add_help=True)
 
-parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="127.0.0.1")
-parser.add_argument('-e', action="store", dest="ES_IP", default="127.0.0.1")
+parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="localhost")
+parser.add_argument('-e', action="store", dest="ES_IP", default="http://localhost:9200")
 
 opts = parser.parse_args()
 
 SCYLLA_IP = opts.SCYLLA_IP.split(',')
 ES_IP = opts.ES_IP.split(',')
 
-
-## Define KS + Table
+## Define KeySpace + Table
 create_ks = "CREATE KEYSPACE IF NOT EXISTS catalog WITH replication = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3};"
-create_t1 = "CREATE TABLE IF NOT EXISTS catalog.apparel (sku text, brand text, group text, sub_group text, color text, size text, gender text, PRIMARY KEY ((sku),color,size));"
+create_t1 = "CREATE TABLE IF NOT EXISTS catalog.apparel (sku text, brand text, group text, sub_group text, color text, size text, gender text, PRIMARY KEY ((sku), color, size));"
 
-
-## Loading the data
+# Loading the data
 def load_data(filename):
     data = []
     headers = []
-    with open(filename, "r") as f:
+    with open(filename, 'r') as f:
         reader = csv.reader(f)
         headers = next(reader) # read the headers line
-
-        for l in reader:
+        
+        for line in reader:
             doc = {}
-            for i in range(0, len(l)):
-                doc[headers[i].lower()] = l[i]
+            for i in range(0, len(line)):
+                doc[headers[i].lower()] = line[i]
 
             data.append(doc)
-
+            
     return headers, data
 
-
-## Insert the data
+# Insert the data
 def insert_data(headers, data):
     ## Connect to Scylla cluster and create schema
-    # session = cassandra.cluster.Cluster(SCYLLA_IP).connect()
     print("")
     print("## Connecting to Scylla cluster -> Creating schema")
     session = Cluster(SCYLLA_IP).connect()
     session.execute(create_ks)
     session.execute(create_t1)
-
-    ## Connect to Elasticsearch
-    print ("")
-    print ("## Connecting to Elasticsearch -> Creating 'Catalog' index")
-    es = Elasticsearch(ES_IP)
     
-    ## Create Elasticsearch index. Ignore 400 = IF NOT EXIST
-    es.indices.create(index="catalog", ignore=400)
-
+    ## Connect to Elasticsearch
+    print("")
+    print("## Connecting to Elasticsearch -> Creating 'Catalog' index")
+    
+    # Ignore status 400 = 'IF NOT EXISTS' for index creation
+    es = Elasticsearch(ES_IP).options(ignore_status=400)
+    
+    ## Create Elasticsearch index
+    es.indices.create(index='catalog')
+    
     ## Non-prepared CQL statement
     #cql = "INSERT INTO catalog.apparel(sku,brand,group,sub_group,color,size,gender) VALUES(%(sku)s,%(brand)s,%(group)s,%(sub_group)s,%(color)s,%(size)s,%(gender)s)"
 
     ## Prepared CQL statement
     print("")
-    print("## Preparing CQL statement")
-    cql = "INSERT INTO catalog.apparel (sku,brand,group,sub_group,color,size,gender) VALUES (?,?,?,?,?,?,?) using TIMESTAMP ?"
+    print("## Preparing CQL and ES queries")
+    cql = "INSERT INTO catalog.apparel (sku, brand, group, sub_group, color, size, gender) VALUES (?, ?, ?, ?, ?, ?, ?) USING TIMESTAMP ?"
     cql_prepared = session.prepare(cql)
     cql_prepared.consistency_level = ConsistencyLevel.ONE if random.random() < 0.2 else ConsistencyLevel.QUORUM
 
     print("")
-    print("## Insert csv content into Scylla and Elasticsearch")
-
-
-    for d in data: 
+    print("## Inserting data into Scylla and Elasticsearch")
+    
+    for row in data:
         # See if we need to add code to wait for the ack. This should be synchronous.
         # Also, might need to switch to prepared statements to set the consistency level for sync requests.
-        session.execute(cql_prepared, d)
+        session.execute(cql_prepared, row)
+        
+        es.index(index="catalog", id=row["sku"], body=row)
 
-        res = es.index(index="catalog", doc_type="apparel", id=d["sku"], body=d)
-
-    ## After all the inserts, make a refresh, just in case
+        print(f"Inserted {row['sku']} into Scylla and Elasticsearch")
+    
     print("")
     print("## Inserts completed, refreshing index")
     es.indices.refresh(index="catalog")
-
+    
     print("")
-
-
+        
 if __name__ == "__main__":
-    headers, data = load_data("./catalog.csv")
+    headers, data = load_data('./catalog.csv')
     insert_data(headers, data)

--- a/scylla_elasticsearch_integration/query_data_from_scylla+elastic.py
+++ b/scylla_elasticsearch_integration/query_data_from_scylla+elastic.py
@@ -4,20 +4,17 @@
 
 ### Using elasticsearch-py ###
 from cassandra.cluster import Cluster
+from cassandra import ConsistencyLevel
 from elasticsearch import Elasticsearch
 
 import random
 import argparse
-import concurrent.futures
-from cassandra import ConsistencyLevel
-from cassandra.concurrent import execute_concurrent_with_args
 
-
-## Script args and help
+## Script args and Help
 parser = argparse.ArgumentParser(add_help=True)
 
-parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="127.0.0.1")
-parser.add_argument('-e', action="store", dest="ES_IP", default="127.0.0.1")
+parser.add_argument('-s', action="store", dest="SCYLLA_IP", default="localhost")
+parser.add_argument('-e', action="store", dest="ES_IP", default="http://localhost:9200")
 parser.add_argument('-n', action="store", dest="NUM_FILTERS", default="multiple")
 
 opts = parser.parse_args()
@@ -25,73 +22,61 @@ opts = parser.parse_args()
 SCYLLA_IP = opts.SCYLLA_IP.split(',')
 ES_IP = opts.ES_IP.split(',')
 
-
 def query_es(NUM_FILTERS):
 
     ## Connect to Elasticsearch
     print("")
     print("## Connecting to Elasticsearch")
     es = Elasticsearch(ES_IP)
-
+    
     if NUM_FILTERS == 'single':
         ## Search using single field filter (group: 'pants')
         print("")
         print("## Searching for 'pants' in Elasticsearch (filter by group)")
-        res = es.search(index="catalog", doc_type="apparel", body={"query": {"match": {"group": "pants"}}, "size": 1000})
-
+        res = es.search(index="catalog", body={"query": {"match": {"group": "pants"}}, "size": 1000})
+        
     if NUM_FILTERS == 'multiple':
         ## Search using multiple fields filter (color: 'white' AND sub_group: 'softshell')
         print("")
         print("## Searching for 'white softshell' in Elasticsearch (filter by color + sub_group)")
-        res = es.search(index="catalog", doc_type="apparel", body={"query": {"bool": {"must": [{"match": {"color": "white"}}, {"match": {"sub_group": "softshell"}}]}}, "size": 1000})
-
+        res = es.search(index="catalog", body={"query": {"bool": {"must": [{"match": {"color": "white"}}, {"match": {"sub_group": "softshell"}}]}}, "size": 1000})
+    
     if NUM_FILTERS == 'none':
         ## Search with NO filters (match_all)
         print("")
         print("## Searching with NO filter = 'match_all' in Elasticsearch")
-        res = es.search(index="catalog", doc_type="apparel", body={"query": {"match_all": {}}, "size": "1000"})
-
+        res = es.search(index="catalog", body={"query": {"match_all": {}}, "size": "1000"})
+    
     print("")
-    print("## %d documents returned" % res['hits']['total'])
-
+    print(f"## {res['hits']['total']['value']} documents returned")
+    
     es_results = [doc['_id'] for doc in res['hits']['hits']]
-
-    ## Connect to Scylla
-    print("")
+    
     print("## Connecting to Scylla")
     session = Cluster(SCYLLA_IP).connect()
-
-
-    ## Prepared cql statement
-    print("")
-    print("## Preparing CQL statement")
-    cql = "SELECT * FROM catalog.apparel WHERE sku=?"
+    
+    ## Prepare the CQL query
+    cql = "SELECT * FROM catalog.apparel WHERE sku = ?"
     cql_prepared = session.prepare(cql)
     cql_prepared.consistency_level = ConsistencyLevel.ONE if random.random() < 0.2 else ConsistencyLevel.QUORUM
-
-
+    
     ## Query Scylla
-    print("")
     print("## Query Scylla using SKU/s returned from Elasticsearch")
-
-    print("")
     print("## Final results from Scylla:")
-    print("")
+    
     for r in es_results:
         scylla_res = session.execute(cql_prepared, (r,))
-        print("%s" % ([list(row) for row in scylla_res]))
-
-
-    #for doc in res['hits']['hits']:
+        
+        ## Print all columns in Scylla result set
+        print([list(row) for row in scylla_res])
+    
+    for doc in res['hits']['hits']:
 
         ## Print all columns in Elasticsearch result set
-        #print("SKU: %s | Color: %s | Size: %s | Brand: %s | Gender: %s | Group: %s | Sub_Group: %s" % (doc['_id'], doc['_source']['color'], doc['_source']['size'], doc['_source']['brand'], doc['_source']['gender'], doc['_source']['group'], doc['_source']['sub_group']))
+        print(f"SKU: {doc['_id']} | Color: {doc['_source']['color']} | Size: {doc['_source']['size']} | Brand: {doc['_source']['brand']} | Gender: {doc['_source']['gender']} | Group: {doc['_source']['group']} | Sub_Group: {doc['_source']['sub_group']}")
 
         ## Print only the id (sku) in the result set
-        #print("SKU: %s" % (doc['_id']))
-
-    print("")
-
+        print("SKU: %s" % (doc['_id']))
+        
 if __name__ == '__main__':
     query_es(opts.NUM_FILTERS)
-


### PR DESCRIPTION
Removed deprecated practices:
- Eliminated references to `doc_type` in Elasticsearch queries (no longer required).
- Mentioned default port number for Elasticsearch
- Addressed a deprecation warning by using client.options for ignoring index creation existence (400 status).
- Enhanced Readability: Improved code formatting and removed unnecessary comments for better maintainability.