### PR TITLE
Chunking demo

### DIFF
--- a/chunking-large-cells/cpp/CMakeLists.txt
+++ b/chunking-large-cells/cpp/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.16)
+project(salted_blob_store_cpp CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+# Preferred driver: ScyllaDB C++ Driver (cpp-rs-driver).
+#   https://cpp-rs-driver.docs.scylladb.com/stable/
+#   pkg-config module : scylla-cpp-driver
+#   shared library    : libscylla-cpp-driver.so
+# Falls back to the legacy DataStax cassandra driver if the Scylla package is absent.
+
+# RPM-based distros (Rocky, Fedora) install .pc files under /usr/lib64/pkgconfig,
+# which pkg-config ignores unless that path is in PKG_CONFIG_PATH.
+# Homebrew (macOS) installs .pc files under /opt/homebrew/lib/pkgconfig.
+set(ENV{PKG_CONFIG_PATH}
+    "/usr/lib64/pkgconfig:/usr/local/lib64/pkgconfig:/opt/homebrew/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(CASSANDRA QUIET scylla-cpp-driver)
+    if(NOT CASSANDRA_FOUND)
+        pkg_check_modules(CASSANDRA QUIET cassandra)
+    endif()
+endif()
+
+if(CASSANDRA_FOUND)
+    # Build the interface target manually so that CASSANDRA_LIBRARY_DIRS is
+    # wired in as a proper link directory. CMake 3.16's IMPORTED_TARGET does
+    # not reliably propagate -L flags from pkg-config into the linker command.
+    add_library(cassandra_pkgconfig INTERFACE)
+    target_include_directories(cassandra_pkgconfig INTERFACE ${CASSANDRA_INCLUDE_DIRS})
+    target_link_libraries(cassandra_pkgconfig INTERFACE ${CASSANDRA_LIBRARIES})
+    target_link_directories(cassandra_pkgconfig INTERFACE ${CASSANDRA_LIBRARY_DIRS})
+    target_compile_options(cassandra_pkgconfig INTERFACE ${CASSANDRA_CFLAGS_OTHER})
+    # Embed rpath so the runtime linker finds the library without requiring
+    # /usr/lib64 to be in ld.so.conf or LD_LIBRARY_PATH.
+    # pkg-config may strip "system" -L paths, so fall back to /usr/lib64.
+    if(CASSANDRA_LIBRARY_DIRS)
+        foreach(_dir IN LISTS CASSANDRA_LIBRARY_DIRS)
+            target_link_options(cassandra_pkgconfig INTERFACE "-Wl,-rpath,${_dir}")
+        endforeach()
+    else()
+        target_link_options(cassandra_pkgconfig INTERFACE "-Wl,-rpath,/usr/lib64")
+    endif()
+    set(CASSANDRA_TARGET cassandra_pkgconfig)
+else()
+    find_path(CASSANDRA_INCLUDE_DIR
+        NAMES cassandra.h
+        PATHS /usr/include /usr/local/include
+              /opt/homebrew/include)
+    find_library(CASSANDRA_LIBRARY
+        NAMES scylla-cpp-driver cassandra
+        PATHS /usr/lib64 /usr/local/lib64 /usr/lib /usr/local/lib
+              /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
+              /opt/homebrew/lib)
+    if(NOT CASSANDRA_INCLUDE_DIR OR NOT CASSANDRA_LIBRARY)
+        message(FATAL_ERROR
+            "ScyllaDB C++ driver not found.\n"
+            "Preferred: install scylla-cpp-driver-dev and scylla-cpp-driver (Ubuntu/Debian) or\n"
+            "           scylla-cpp-driver-devel (RPM) from\n"
+            "           https://cpp-rs-driver.docs.scylladb.com/stable/topics/installation.html\n"
+            "Fallback : cassandra-cpp-driver-dev / libcassandra-dev (DataStax)\n"
+            "Or set CMAKE_PREFIX_PATH to a custom install prefix.")
+    endif()
+    # Derive rpath from the full path find_library resolved.
+    get_filename_component(_cassandra_lib_dir "${CASSANDRA_LIBRARY}" DIRECTORY)
+    add_library(cassandra_external INTERFACE)
+    target_include_directories(cassandra_external INTERFACE ${CASSANDRA_INCLUDE_DIR})
+    target_link_libraries(cassandra_external INTERFACE ${CASSANDRA_LIBRARY})
+    target_link_options(cassandra_external INTERFACE "-Wl,-rpath,${_cassandra_lib_dir}")
+    set(CASSANDRA_TARGET cassandra_external)
+endif()
+
+add_library(salted_blob_store STATIC salted_blob_store.cpp salted_blob_store.h)
+target_include_directories(salted_blob_store PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(salted_blob_store PUBLIC ${CASSANDRA_TARGET})
+target_compile_options(salted_blob_store PRIVATE -Wall -Wextra -Wpedantic)
+
+add_executable(demo demo.cpp)
+target_link_libraries(demo PRIVATE salted_blob_store)
+target_compile_options(demo PRIVATE -Wall -Wextra -Wpedantic)
+
+add_executable(benchmark benchmark.cpp)
+target_link_libraries(benchmark PRIVATE salted_blob_store)
+target_compile_options(benchmark PRIVATE -Wall -Wextra -Wpedantic)

--- a/chunking-large-cells/cpp/README.md
+++ b/chunking-large-cells/cpp/README.md
@@ -1,0 +1,282 @@
+# Chunking large cells — C++ demo
+
+C++23 port of [`../python`](../python/) using the
+[ScyllaDB C++ Driver (cpp-rs-driver)](https://cpp-rs-driver.docs.scylladb.com/stable/)
+(`libscylla-cpp-driver`). The DataStax driver (`libcassandra`) is also
+supported as a fallback — both expose the same `cassandra.h` API.
+
+## Files
+
+| File                           | Purpose                                                                                                                         |
+|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| `salted_blob_store.h` / `.cpp` | Library: schema management, write, read, erase, describe                                                                        |
+| `demo.cpp`                     | End-to-end demo (small / medium / large blobs, round-trip verification)                                                         |
+| `benchmark.cpp`                | Large-blob vs small-blob throughput and latency benchmark                                                                       |
+| `CMakeLists.txt`               | Build configuration (`pkg-config` used when available; falls back to `find_library` if absent or if no pkg-config module found) |
+
+## Schema
+
+```cql
+CREATE TABLE <keyspace>.salted_blobs (
+    key blob,
+    salt int,
+    chunk_id int,
+    chunk blob,
+    total_chunks int,
+    salt_cardinality int,
+    PRIMARY KEY ((key, salt), chunk_id)
+);
+```
+
+## Prerequisites
+
+The [ScyllaDB C++ Driver (cpp-rs-driver)](https://cpp-rs-driver.docs.scylladb.com/stable/),
+CMake 3.16+, and a C++23-capable compiler:
+
+* **Ubuntu / Debian** — download the runtime and dev `.deb` packages from the
+  [releases page](https://github.com/scylladb/cpp-rs-driver/releases) and install:
+  ```bash
+  apt install ./scylla-cpp-driver_*.deb ./scylla-cpp-driver-dev_*.deb
+  apt install cmake g++-14 pkg-config
+  ```
+  Ubuntu 24.04's default `g++` (GCC 13) lacks `<print>`; GCC 14 is required
+  for full C++23 support. See the [Build](#build) section for how to point CMake
+  at `g++-14`.
+* **RHEL / Rocky / Fedora** — download the matching `.rpm` packages from the
+  [releases page](https://github.com/scylladb/cpp-rs-driver/releases) and install:
+  ```bash
+  dnf install scylla-cpp-driver-*.rpm scylla-cpp-driver-devel-*.rpm
+  dnf install cmake gcc-c++ pkgconf-pkg-config
+  ```
+* **macOS (Homebrew)** — no Scylla driver formula exists yet; the DataStax
+  driver is used as a fallback:
+  ```bash
+  brew install cmake pkg-config cassandra-cpp-driver
+  ```
+  CMake finds the Homebrew-installed headers and library automatically via the
+  `/opt/homebrew/include` / `/opt/homebrew/lib` search paths.
+* **Build from source** — <https://cpp-rs-driver.docs.scylladb.com/stable/topics/building.html>.
+* **Fallback** — the DataStax `cassandra-cpp-driver-dev` / `libcassandra-dev`
+  package also works on Linux; CMake detects it automatically if the Scylla
+  package is absent.
+
+> **Note:** both the runtime package (`scylla-cpp-driver`) and the dev package
+> (`scylla-cpp-driver-dev` / `-devel`) are required. The dev package provides
+> `cassandra.h` and the `.so` symlink; the runtime package provides the versioned
+> `.so` that the linker and dynamic loader need.
+
+## Build
+
+```bash
+cd chunking-large-cells/cpp
+cmake -S . -B build
+cmake --build build -j
+```
+
+On **Ubuntu 24.04**, point CMake at GCC 14 explicitly (the default `g++` is
+GCC 13, which lacks C++23's `<print>`):
+
+```bash
+CC=gcc-14 CXX=g++-14 cmake -S . -B build
+cmake --build build -j
+```
+
+CMake uses `pkg-config` when available to locate the driver (searching
+`scylla-cpp-driver` first, then `cassandra`). If `pkg-config` is absent or
+neither module is found, it falls back to `find_path`/`find_library` across the
+standard system and Homebrew prefixes. On RPM-based distros the `.pc` file is in
+`/usr/lib64/pkgconfig`; CMake prepends that path to `PKG_CONFIG_PATH`
+automatically.
+
+The build embeds an rpath into the binary so `libscylla-cpp-driver.so` is found
+at runtime without needing `LD_LIBRARY_PATH` or changes to `/etc/ld.so.conf`.
+
+## Run
+
+Spin up a single-node ScyllaDB and run the demo:
+
+```bash
+docker run --name scylla-blobs -d -p 9042:9042 scylladb/scylla \
+    --smp 2 --memory 2G --overprovisioned 1
+
+./build/demo --contact-points 127.0.0.1 --large-mb 30
+
+# Cap in-flight CQL futures to a sliding window of 32 (default: 0 = unlimited)
+./build/demo --contact-points 127.0.0.1 --large-mb 30 --max-concurrency 32
+```
+
+The demo will:
+
+1. create keyspace `salted_blob_demo` and table `salted_blobs`,
+2. write a 2 KiB blob with `max_salt=1` (no chunking),
+3. write a 256 KiB blob with `max_salt=8` (a handful of salts),
+4. write a `--large-mb`-sized blob (default 8 MiB) with `max_salt=100`, `chunk_size=64 KiB`,
+5. round-trip every blob and verify with an FNV-1a fingerprint and `std::ranges::equal` over the flattened chunk vector,
+6. dump how each blob is laid out across salted partitions,
+7. show that `read()` of a missing key returns `std::nullopt`,
+8. delete a key and confirm it's gone.
+
+Pass `--cleanup` to drop the keyspace at the end.  
+Use `--max-concurrency N` to cap the number of in-flight CQL futures inside
+each `write()` / `read()` / `erase()` call (default `0` = unlimited — all
+batch / SELECT futures are issued at once and awaited together).  
+Connection settings can also be provided via environment variables:
+`SCYLLA_CONTACT_POINTS`, `SCYLLA_PORT`, `SCYLLA_USERNAME`, `SCYLLA_PASSWORD`.
+
+## Benchmark — large blobs vs small blobs
+
+`benchmark` mirrors [`../python/benchmark.py`](../python/benchmark.py) and
+measures the same total byte volume written and read two ways:
+
+| Case            | What is one "operation"                                                                       |
+|-----------------|-----------------------------------------------------------------------------------------------|
+| **Large blobs** | Write / read one `--large-mb` MiB blob via `SaltedBlobStore` (chunks parallelised internally) |
+| **Small blobs** | One CQL `INSERT` / `SELECT` of a single `--small-kb` KiB row                                  |
+
+The final report prints per-operation latency (min / p50 / p99 / max) and
+aggregate throughput (MiB/s) side-by-side for both cases.
+
+```bash
+# Quick smoke-test: 10 × 30 MiB large blobs ≈ 300 MiB total
+./build/benchmark --count 10
+
+# Full benchmark: 1,000 × 30 MiB ≈ 30 GiB total (requires sufficient disk)
+./build/benchmark --count 1000
+
+# Tune sizes, concurrency, and the store sliding window
+./build/benchmark --count 100 --large-mb 30 --small-kb 128 \
+    --concurrency 128 --max-concurrency 32
+
+# Drop the keyspace when done
+./build/benchmark --count 10 --cleanup
+```
+
+Key flags:
+
+| Flag                  | Default      | Description                                                               |
+|-----------------------|--------------|---------------------------------------------------------------------------|
+| `--contact-points`    | `127.0.0.1`  | Comma-separated ScyllaDB host list (or `SCYLLA_CONTACT_POINTS`)           |
+| `--port`              | `9042`       | CQL port (or `SCYLLA_PORT`)                                               |
+| `--username`          | _(none)_     | CQL username (or `SCYLLA_USERNAME`)                                       |
+| `--password`          | _(none)_     | CQL password (or `SCYLLA_PASSWORD`)                                       |
+| `--keyspace`          | `blob_bench` | Keyspace to use                                                           |
+| `--rf N`              | `1`          | Replication factor                                                        |
+| `--count N`           | `1000`       | Number of large blobs                                                     |
+| `--large-mb M`        | `30`         | Each large blob in MiB                                                    |
+| `--small-kb K`        | `64`         | Each small blob in KiB                                                    |
+| `--chunk-size-kb C`   | `64`         | Chunk size for large-blob salting                                         |
+| `--max-salt S`        | `100`        | Parallel shard spread for large blobs                                     |
+| `--concurrency P`     | `64`         | Async sliding-window size for small-blob ops (must be `>= 1`)             |
+| `--max-concurrency N` | `0`          | Max in-flight futures inside `SaltedBlobStore.write/read` (0 = unlimited) |
+| `--skip-large`        | off          | Reuse already-written large blobs                                         |
+| `--skip-small`        | off          | Skip the small-blob case                                                  |
+| `--cleanup`           | off          | Drop keyspace on exit                                                     |
+
+> **Disk budget**: `count × large_mb` MiB plus the equivalent small-blob
+> volume. For the default `1000 × 30 MiB` run that is roughly **60 GiB**
+> (both tables together with RF=1). Use `--count 10` or `--count 100` for
+> smaller runs.
+
+## Library usage
+
+```cpp
+#include "salted_blob_store.h"
+#include <cassandra.h>
+#include <algorithm>  // std::ranges::equal
+#include <ranges>     // std::views::join
+
+CassCluster* cluster = cass_cluster_new();
+cass_cluster_set_contact_points(cluster, "127.0.0.1");
+cass_cluster_set_protocol_version(cluster, 4);        // required for shard-aware routing
+cass_cluster_set_token_aware_routing(cluster, cass_true);
+CassSession* session = cass_session_new();
+cass_future_wait(cass_session_connect(session, cluster));
+
+scs::SaltedBlobStore store(session, "my_ks");
+store.create_schema(/*replication_factor=*/1);
+
+// Hybrid policy: small blobs stay on a single partition,
+// big blobs spread across many shards.
+store.write(small_key, small_blob, /*max_salt=*/1,   /*chunk_size=*/4096);
+store.write(huge_key,  huge_blob,  /*max_salt=*/100, /*chunk_size=*/64 * 1024);
+
+// max_concurrency > 0 enables a true sliding window via std::counting_semaphore:
+// the callback releases a slot the moment the future completes, immediately
+// unblocking the producer.  0 (default) fires all futures at once.
+store.write(huge_key2, huge_blob, /*max_salt=*/100, /*chunk_size=*/64 * 1024,
+            scs::kDefaultMaxBatchBytes, /*max_concurrency=*/32);
+
+// read() returns the per-chunk vectors; join them to get a flat byte sequence.
+auto chunks = store.read(small_key);             // unlimited concurrency
+auto chunks2 = store.read(huge_key, /*max_concurrency=*/32);  // sliding window
+if (chunks)
+    auto flat = *chunks | std::views::join;  // lazy flat view over all chunk bytes
+
+auto info = store.describe(huge_key);  // std::optional<scs::BlobLayout>
+```
+
+`max_salt` and `chunk_size` are per-call — the same table can hold keys with
+completely different salting parameters.
+
+## Notes
+
+* **`write()` parameter checks** — invalid tuning values throw
+  `std::invalid_argument` before any CQL is issued:
+
+  | Parameter         | Constraint                          |
+  |-------------------|-------------------------------------|
+  | `max_salt`        | `>= 1`                              |
+  | `chunk_size`      | `>= 1`                              |
+  | `max_batch_bytes` | `>= chunk_size` (and `>= 1`)        |
+  | `max_concurrency` | `>= 0` (`0` = unlimited in-flight)  |
+
+  The `max_batch_bytes >= chunk_size` rule guarantees every UNLOGGED batch
+  can hold at least one full chunk, so batch sizing stays predictable
+  relative to the server's `batch_size_fail_threshold_in_kb`.  Default
+  `max_batch_bytes` is 1 MiB (`scs::kDefaultMaxBatchBytes`).
+* **Empty blobs** — `write(key, {})` stores a single sentinel row
+  `(salt=0, chunk_id=0)` with `total_chunks=0`.  `read(key)` short-circuits
+  on that sentinel and returns an empty `std::vector<Bytes>` without issuing
+  any partition SELECTs.
+* Writes use `CASS_BATCH_TYPE_UNLOGGED` per salted partition (one batch per
+  salt, split once the accumulated chunk payload exceeds `max_batch_bytes`
+  — default 1 MiB — to stay under the server's
+  `batch_size_fail_threshold_in_kb`).
+* Reads issue one async per-partition `SELECT` per salt and return the per-chunk
+  byte vectors without an extra copy; `chunk_id` order is reconstructed from the
+  row metadata. Metadata is fetched once via a cheap point query on
+  `(salt=0, chunk_id=0)`.
+* **Metadata validation** — the `KeyMeta` constructor (invoked from
+  `fetch_meta`) throws `std::runtime_error` if the stored sentinel row has a
+  negative `total_chunks` or non-positive `salt_cardinality`, so `read`,
+  `erase`, and `describe` all reject corrupt metadata uniformly instead of
+  silently proceeding with bad values.
+* **Chunk-row integrity** — `read()` rejects rows whose `chunk_id` is out of
+  range or whose payload is empty (an empty chunk row inside a non-empty
+  blob signals corruption, since `write()` only stores empty rows for empty
+  blobs via the `total_chunks=0` sentinel path).
+* **`erase()` ordering** — chunk partitions (`salt != 0`) are removed first;
+  the sentinel partition (`salt=0`, carrying `total_chunks` and
+  `salt_cardinality`) is deleted last.  If an erase fails partway through,
+  the sentinel row is still present so the operation can be retried.
+* **No move semantics** — `SaltedBlobStore` is non-copyable and
+  non-movable (move ctor/assign are explicitly `= delete`) because the
+  cached `CassPrepared*` handles are owning raw pointers.  Wrap instances
+  in `std::unique_ptr<SaltedBlobStore>` or `std::optional<SaltedBlobStore>`
+  if you need them to live inside a container.
+* **Concurrency control** — `write`, `read`, `erase`, and `describe` accept
+  `max_concurrency` (last parameter where applicable):
+  * `0` (default) — all batch / SELECT futures are collected first, then
+    awaited together (unlimited parallelism).
+  * `N > 0` — a `std::counting_semaphore<>(N)` limits in-flight futures to
+    exactly `N`.  Completion callbacks run on driver I/O threads; each one
+    records any error via an atomic `CallbackErr` accumulator and immediately
+    calls `slots.release()`, unblocking the producer for the next future
+    without any FIFO stalling.  A drain loop reacquires all `N` permits after
+    the issue loop before throwing on the first recorded error.
+* All driver handles (`CassFuture`, `CassResult`, `CassIterator`,
+  `CassStatement`, `CassBatch`) are owned by `CassUnique<T, Free>` — a
+  `std::unique_ptr` alias using a single stateless `CassDeleter<auto Free>`
+  template (C++20 auto NTTP). The deleter is empty, so each handle is
+  pointer-sized with no function-pointer storage overhead, and no manual
+  `cass_*_free` calls are needed in the hot paths.

--- a/chunking-large-cells/cpp/benchmark.cpp
+++ b/chunking-large-cells/cpp/benchmark.cpp
@@ -1,0 +1,848 @@
+// Large-blob vs small-blob benchmark for ScyllaDB.
+//
+// Mirrors ../python/benchmark.py.
+//
+// Compares the same total byte volume written and read in two ways:
+//
+//   LARGE BLOB CASE
+//     --count blobs, each --large-mb MiB, stored via Modified-Salting
+//     (SaltedBlobStore: chunked across multiple partitions, reads/writes
+//     parallelised internally with async CQL).  One write() or read() call
+//     constitutes a single "operation" whose wall-clock time is measured.
+//
+//   SMALL BLOB CASE
+//     ceil(count * large_mb / small_kb) blobs, each --small-kb KiB, stored
+//     as a single row per blob (one CQL INSERT or SELECT per operation).
+//     A sliding async window of --concurrency outstanding requests drives
+//     throughput.
+//
+// The final report shows per-operation latency (min / p50 / p99 / max) and
+// aggregate throughput (MiB/s) side-by-side for both cases.
+//
+// Defaults: 1,000 × 30 MiB large blobs  ≈ 29.3 GiB total
+//           matched by ~480,000 × 64 KiB small blobs
+// WARNING : 1,000 × 30 MiB requires ~30 GiB of free disk space on ScyllaDB.
+//           Use --count 10 (or --count 100) for a faster smoke-test.
+
+#include "salted_blob_store.h"
+
+#include <cassandra.h>
+
+#include <algorithm>
+#include <atomic>
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <format>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <print>
+#include <random>
+#include <ranges>
+#include <semaphore>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// RAII wrappers (same pattern as salted_blob_store.cpp)
+// ---------------------------------------------------------------------------
+
+template <auto Free>
+struct CassDeleter {
+    template <typename T> void operator()(T* p) const noexcept { Free(p); }
+};
+
+template <typename T, auto Free>
+using CassUnique = std::unique_ptr<T, CassDeleter<Free>>;
+
+using FuturePtr   = CassUnique<CassFuture,         cass_future_free>;
+using StmtPtr     = CassUnique<CassStatement,      cass_statement_free>;
+using PreparedPtr = CassUnique<const CassPrepared, cass_prepared_free>;
+
+// ---------------------------------------------------------------------------
+// Driver helpers
+// ---------------------------------------------------------------------------
+
+[[noreturn]] void throw_future_error(CassFuture* f, std::string_view where) {
+    const char* msg     = nullptr;
+    std::size_t msg_len = 0uz;
+    cass_future_error_message(f, &msg, &msg_len);
+    throw std::runtime_error(
+        std::format("{}: {}", where, std::string_view{msg, msg_len}));
+}
+
+void wait_check(CassFuture* f, std::string_view where) {
+    cass_future_wait(f);
+    if (cass_future_error_code(f) != CASS_OK) [[unlikely]]
+        throw_future_error(f, where);
+}
+
+void execute_simple(CassSession* session, const std::string& cql) {
+    StmtPtr   stmt{cass_statement_new(cql.c_str(), 0)};
+    FuturePtr fut{cass_session_execute(session, stmt.get())};
+    wait_check(fut.get(), cql);
+}
+
+PreparedPtr prepare_stmt(CassSession* session, const std::string& cql) {
+    FuturePtr fut{cass_session_prepare(session, cql.c_str())};
+    wait_check(fut.get(), "PREPARE " + cql);
+    return PreparedPtr{cass_future_get_prepared(fut.get())};
+}
+
+void bind_blob(CassStatement* stmt, std::size_t idx,
+               std::span<const std::uint8_t> data) {
+    static constexpr std::uint8_t empty = 0;
+    cass_statement_bind_bytes(stmt, idx,
+                              data.empty() ? &empty : data.data(),
+                              data.size());
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+std::string make_ruler(int n = 72) {
+    std::string r;
+    r.reserve(static_cast<std::size_t>(n) * 3uz);
+    for (int i = 0; i < n; ++i) r += "━";
+    return r;
+}
+const std::string kRuler = make_ruler();
+
+// Formats a byte count as a human-readable IEC string (B / KiB / MiB …).
+std::string fmt_bytes(double n) {
+    static constexpr std::array<std::string_view, 6> units{
+        "B", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    std::size_t u = 0uz;
+    while (std::abs(n) >= 1024.0 && u + 1uz < units.size())
+        { n /= 1024.0; ++u; }
+    return std::format("{:.2f} {}", n, units[u]);
+}
+
+// Formats a duration in milliseconds; switches to seconds above 1 000 ms.
+std::string fmt_ms(double ms) {
+    return ms < 1000.0 ? std::format("{:.1f} ms", ms)
+                       : std::format("{:.2f} s",  ms / 1000.0);
+}
+
+// Formats a duration in seconds; switches to "Xm Ys" above 60 s.
+std::string fmt_s(double s) {
+    if (s < 60.0) return std::format("{:.1f} s", s);
+    return std::format("{}m {:.0f}s",
+                       static_cast<int>(s / 60.0), std::fmod(s, 60.0));
+}
+
+// Formats an integer with comma thousands separators (e.g. 1,234,567).
+std::string fmt_count(std::size_t n) {
+    std::string s = std::to_string(n);
+    int pos = static_cast<int>(s.size()) - 3;
+    while (pos > 0) { s.insert(static_cast<std::size_t>(pos), ","); pos -= 3; }
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// Percentile — linear interpolation, matches Python's implementation.
+// Takes data by value so it can sort without disturbing the caller's vector.
+// ---------------------------------------------------------------------------
+
+double percentile(std::vector<double> data, double p) {
+    if (data.empty()) return 0.0;
+    std::ranges::sort(data);
+    const double idx = p / 100.0 * static_cast<double>(data.size() - 1uz);
+    const auto   lo  = static_cast<std::size_t>(idx);
+    const auto   hi  = std::min(lo + 1uz, data.size() - 1uz);
+    return data[lo] + (data[hi] - data[lo]) * (idx - static_cast<double>(lo));
+}
+
+// ---------------------------------------------------------------------------
+// Progress bar — overwrites the current line via '\r'.
+// ---------------------------------------------------------------------------
+
+void print_progress(int done, int total,
+                    std::chrono::steady_clock::time_point t_start) {
+    const double elapsed = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t_start).count();
+    const double frac = total > 0
+                      ? static_cast<double>(done) / static_cast<double>(total)
+                      : 0.0;
+    const double eta  = frac > 0.0 ? elapsed / frac - elapsed : 0.0;
+
+    constexpr int kWidth = 30;
+    const int filled = static_cast<int>(kWidth * frac);
+    std::string bar;
+    bar.reserve(static_cast<std::size_t>(kWidth) * 3uz);
+    for (int i = 0; i < filled;          ++i) bar += "█";
+    for (int i = filled; i < kWidth; ++i) bar += "░";
+
+    const int tw = static_cast<int>(std::to_string(total).size());
+    std::print("\r  [{}] {:>{}}/{}  {:.0f}s elapsed  ~{:.0f}s left   ",
+               bar, done, tw, total, elapsed, eta);
+    std::fflush(stdout);
+}
+
+// ---------------------------------------------------------------------------
+// Payload generation — pseudo-random, non-cryptographic.
+// Content is irrelevant for an I/O benchmark; only byte count matters.
+// ---------------------------------------------------------------------------
+
+scs::Bytes make_payload(std::size_t size) {
+    std::mt19937_64 rng{std::random_device{}()};
+    scs::Bytes      buf(size);
+    std::size_t     i = 0uz;
+    while (i + 8uz <= size) {
+        const std::uint64_t v = rng();
+        std::memcpy(buf.data() + i, &v, 8);
+        i += 8uz;
+    }
+    if (i < size) {
+        const auto bytes = std::bit_cast<std::array<std::uint8_t, 8>>(rng());
+        std::copy_n(bytes.begin(), size - i, buf.data() + i);
+    }
+    return buf;
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark result — per-operation latencies (ms) + total wall time (s).
+// ---------------------------------------------------------------------------
+
+struct BenchResult {
+    std::vector<double> write_ms;
+    std::vector<double> read_ms;
+    double              write_wall_s = 0.0;
+    double              read_wall_s  = 0.0;
+};
+
+// ---------------------------------------------------------------------------
+// Large-blob benchmark
+// ---------------------------------------------------------------------------
+
+/// Writes then reads @p count large blobs via SaltedBlobStore.
+/// Each write()/read() call is one measured operation.
+BenchResult bench_large(scs::SaltedBlobStore&         store,
+                        int                           count,
+                        std::size_t                   blob_size,
+                        int                           max_salt,
+                        std::size_t                   chunk_size,
+                        std::span<const std::uint8_t> payload,
+                        int                           store_concurrency) {
+    // Pre-build keys: "bench-large-0000001", "bench-large-0000002", …
+    std::vector<std::string> keys;
+    keys.reserve(static_cast<std::size_t>(count));
+    for (int i : std::views::iota(0, count))
+        keys.push_back(std::format("bench-large-{:07d}", i));
+
+    const int report_step = std::max(1, count / 50);
+
+    BenchResult res;
+    res.write_ms.reserve(static_cast<std::size_t>(count));
+    res.read_ms.reserve(static_cast<std::size_t>(count));
+
+    // ── WRITE ────────────────────────────────────────────────────────────────
+    std::println("\n{}", kRuler);
+    std::println("  LARGE BLOB WRITE  —  {} × {}",
+                 fmt_count(static_cast<std::size_t>(count)),
+                 fmt_bytes(static_cast<double>(blob_size)));
+    std::println("{}", kRuler);
+
+    const auto t_write_wall = std::chrono::steady_clock::now();
+    for (int i : std::views::iota(0, count)) {
+        const auto key = std::span{
+            reinterpret_cast<const std::uint8_t*>(keys[i].data()),
+            keys[i].size()};
+        const auto t0 = std::chrono::steady_clock::now();
+        store.write(key, payload, max_salt, chunk_size,
+                    scs::kDefaultMaxBatchBytes, store_concurrency);
+        res.write_ms.push_back(std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - t0).count());
+        if ((i + 1) % report_step == 0 || i + 1 == count)
+            print_progress(i + 1, count, t_write_wall);
+    }
+    res.write_wall_s = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t_write_wall).count();
+    std::println("\n  done in {}  ({}/s)",
+                 fmt_s(res.write_wall_s),
+                 fmt_bytes(static_cast<double>(count) *
+                           static_cast<double>(blob_size) / res.write_wall_s));
+
+    // ── READ ─────────────────────────────────────────────────────────────────
+    std::println("\n{}", kRuler);
+    std::println("  LARGE BLOB READ   —  {} × {}",
+                 fmt_count(static_cast<std::size_t>(count)),
+                 fmt_bytes(static_cast<double>(blob_size)));
+    std::println("{}", kRuler);
+
+    const auto t_read_wall = std::chrono::steady_clock::now();
+    for (int i : std::views::iota(0, count)) {
+        const auto key = std::span{
+            reinterpret_cast<const std::uint8_t*>(keys[i].data()),
+            keys[i].size()};
+        const auto t0 = std::chrono::steady_clock::now();
+        auto chunks = store.read(key, store_concurrency);
+        res.read_ms.push_back(std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - t0).count());
+        if (!chunks)
+            throw std::runtime_error(
+                std::format("missing blob for key '{}'", keys[i]));
+        if ((i + 1) % report_step == 0 || i + 1 == count)
+            print_progress(i + 1, count, t_read_wall);
+    }
+    res.read_wall_s = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t_read_wall).count();
+    std::println("\n  done in {}  ({}/s)",
+                 fmt_s(res.read_wall_s),
+                 fmt_bytes(static_cast<double>(count) *
+                           static_cast<double>(blob_size) / res.read_wall_s));
+
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+// Small-blob async machinery
+//
+// Per-op state passed through the void* user-data slot of
+// cass_future_set_callback. Lives on the heap; the callback owns it.
+// ---------------------------------------------------------------------------
+
+struct OpCtx {
+    std::chrono::steady_clock::time_point t0;
+    std::size_t                           op_idx;
+    std::vector<double>*                  lats;       ///< Pre-sized; written at op_idx without lock.
+    std::counting_semaphore<>*            slots;      ///< Released here → unblocks producer.
+    std::atomic<int>*                     completed;  ///< Approximate progress counter.
+    std::atomic<int>*                     errors;
+    std::mutex*                           err_mutex;
+    std::string*                          first_err;
+};
+
+/// Driver-thread completion callback.
+///
+/// Invoked exactly once per future. Marked noexcept because exceptions
+/// thrown from a C-driver callback cannot propagate and would call
+/// std::terminate anyway — making the intent explicit.
+void on_op_done(CassFuture* fut, void* data) noexcept {
+    auto* const ctx = static_cast<OpCtx*>(data);
+    const double ms = std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now() - ctx->t0).count();
+    (*ctx->lats)[ctx->op_idx] = ms;
+
+    if (cass_future_error_code(fut) != CASS_OK) [[unlikely]] {
+        const char* msg = nullptr;
+        std::size_t mlen = 0uz;
+        cass_future_error_message(fut, &msg, &mlen);
+        std::lock_guard lk{*ctx->err_mutex};
+        if (ctx->first_err->empty())
+            ctx->first_err->assign(msg, mlen);
+        ctx->errors->fetch_add(1, std::memory_order_relaxed);
+    }
+    ctx->completed->fetch_add(1, std::memory_order_release);
+
+    // Snapshot the semaphore pointer before deleting ctx; release() is the
+    // last step so the producer can't observe ctx-not-yet-cleaned-up.
+    auto* const slots = ctx->slots;
+    cass_future_free(fut);
+    delete ctx;
+    slots->release();
+}
+
+// ---------------------------------------------------------------------------
+// Small-blob benchmark
+// ---------------------------------------------------------------------------
+
+/// Writes then reads small blobs totalling @p total_bytes.
+/// Each operation is a single CQL INSERT or SELECT, driven by a true
+/// sliding-window of @p concurrency in-flight requests: the moment any
+/// outstanding op completes, the producer wakes and issues the next one
+/// (no batch-stalling).
+BenchResult bench_small(CassSession*                  session,
+                        std::string_view               keyspace,
+                        std::size_t                    total_bytes,
+                        std::size_t                    small_size,
+                        std::span<const std::uint8_t>  payload,
+                        int                            concurrency) {
+    if (concurrency < 1) throw std::invalid_argument("concurrency must be >= 1");
+    const int n_ops = static_cast<int>(
+        (total_bytes + small_size - 1uz) / small_size);  // ceil
+
+    // Pre-build keys: "bench-small-0000000001", …
+    std::vector<std::string> keys;
+    keys.reserve(static_cast<std::size_t>(n_ops));
+    for (int i : std::views::iota(0, n_ops))
+        keys.push_back(std::format("bench-small-{:010d}", i));
+
+    execute_simple(session, std::format(
+        "CREATE TABLE IF NOT EXISTS {}.small_blobs "
+        "(key blob PRIMARY KEY, data blob)", keyspace));
+
+    PreparedPtr stmt_w = prepare_stmt(session, std::format(
+        "INSERT INTO {}.small_blobs (key, data) VALUES (?, ?)", keyspace));
+    PreparedPtr stmt_r = prepare_stmt(session, std::format(
+        "SELECT data FROM {}.small_blobs WHERE key = ?", keyspace));
+
+    const int report_step = std::max(1, n_ops / 50);
+
+    BenchResult res;
+    res.write_ms.reserve(static_cast<std::size_t>(n_ops));
+    res.read_ms.reserve(static_cast<std::size_t>(n_ops));
+
+    // True sliding-window: the producer holds at most `concurrency` permits,
+    // each completion's callback releases one. The producer therefore never
+    // waits for a "round" to drain — as soon as any single op completes, the
+    // next op is issued. `make_stmt(j)` returns a new CassStatement* owned by
+    // the caller (wrapped in StmtPtr immediately).
+    auto run_window = [&](auto make_stmt,
+                          std::vector<double>& lats,
+                          double& wall_s,
+                          std::string_view heading) {
+        std::println("\n{}", kRuler);
+        std::println("{}", heading);
+        std::println("{}", kRuler);
+
+        lats.assign(static_cast<std::size_t>(n_ops), 0.0);
+
+        std::counting_semaphore<> slots(concurrency);
+        std::atomic<int>          completed{0};
+        std::atomic<int>          errors{0};
+        std::mutex                err_mutex;
+        std::string               first_err;
+
+        const auto t_wall        = std::chrono::steady_clock::now();
+        int        last_reported = 0;
+
+        // Issue loop: acquire a permit (blocks until one is free), then fire
+        // the next op. The callback releases its permit on completion.
+        int issued = 0;
+        for (; issued < n_ops; ++issued) {
+            slots.acquire();
+            if (errors.load(std::memory_order_acquire) > 0) [[unlikely]] {
+                slots.release();   // Permit unused — restore the invariant.
+                break;
+            }
+
+            StmtPtr stmt{make_stmt(issued)};
+            auto* const ctx = new OpCtx{
+                .t0        = std::chrono::steady_clock::now(),
+                .op_idx    = static_cast<std::size_t>(issued),
+                .lats      = &lats,
+                .slots     = &slots,
+                .completed = &completed,
+                .errors    = &errors,
+                .err_mutex = &err_mutex,
+                .first_err = &first_err,
+            };
+            CassFuture* const fut = cass_session_execute(session, stmt.get());
+            if (cass_future_set_callback(fut, &on_op_done, ctx) != CASS_OK) [[unlikely]] {
+                delete ctx;
+                cass_future_free(fut);
+                slots.release();
+                std::lock_guard lk{err_mutex};
+                if (first_err.empty()) first_err = "cass_future_set_callback failed";
+                errors.fetch_add(1, std::memory_order_relaxed);
+                break;
+            }
+
+            const int done_now = completed.load(std::memory_order_acquire);
+            if (done_now >= last_reported + report_step) {
+                print_progress(done_now, n_ops, t_wall);
+                last_reported = done_now;
+            }
+        }
+
+        // Drain: wait for every outstanding callback to release its permit.
+        // try_acquire_for lets us also tick progress during the drain.
+        int acquired = 0;
+        while (acquired < concurrency) {
+            if (slots.try_acquire_for(std::chrono::milliseconds(200)))
+                ++acquired;
+            const int done_now = completed.load(std::memory_order_acquire);
+            if (done_now > last_reported) {
+                print_progress(done_now, n_ops, t_wall);
+                last_reported = done_now;
+            }
+        }
+
+        wall_s = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t_wall).count();
+        print_progress(completed.load(), n_ops, t_wall);
+
+        if (errors.load() > 0) [[unlikely]] {
+            std::lock_guard lk{err_mutex};
+            throw std::runtime_error(
+                std::format("small blob op failed after {} issued: {}",
+                            issued, first_err));
+        }
+
+        std::println("\n  done in {}  ({}/s)",
+                     fmt_s(wall_s),
+                     fmt_bytes(static_cast<double>(total_bytes) / wall_s));
+    };
+
+    // ── WRITE ────────────────────────────────────────────────────────────────
+    run_window(
+        [&](int j) -> CassStatement* {
+            CassStatement* s = cass_prepared_bind(stmt_w.get());
+            const auto key = std::span{
+                reinterpret_cast<const std::uint8_t*>(keys[j].data()),
+                keys[j].size()};
+            bind_blob(s, 0, key);
+            bind_blob(s, 1, payload);
+            return s;
+        },
+        res.write_ms, res.write_wall_s,
+        std::format("  SMALL BLOB WRITE  —  {} × {}  (concurrency={})",
+                    fmt_count(static_cast<std::size_t>(n_ops)),
+                    fmt_bytes(static_cast<double>(small_size)),
+                    concurrency));
+
+    // ── READ ─────────────────────────────────────────────────────────────────
+    run_window(
+        [&](int j) -> CassStatement* {
+            CassStatement* s = cass_prepared_bind(stmt_r.get());
+            const auto key = std::span{
+                reinterpret_cast<const std::uint8_t*>(keys[j].data()),
+                keys[j].size()};
+            bind_blob(s, 0, key);
+            return s;
+        },
+        res.read_ms, res.read_wall_s,
+        std::format("  SMALL BLOB READ   —  {} × {}  (concurrency={})",
+                    fmt_count(static_cast<std::size_t>(n_ops)),
+                    fmt_bytes(static_cast<double>(small_size)),
+                    concurrency));
+
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+// Summary report
+// ---------------------------------------------------------------------------
+
+/// Prints the comparison table.
+///
+/// Either result may be std::nullopt (when --skip-large / --skip-small was
+/// given); every cell that belongs to the skipped case shows "X".
+/// @p n_small is the expected op count for the small case (used when
+/// small is nullopt so the Op count row still shows a meaningful number).
+void report(const std::optional<BenchResult>& large,
+            const std::optional<BenchResult>& small,
+            std::size_t                        large_blob_size,
+            int                                large_count,
+            std::size_t                        small_blob_size,
+            std::size_t                        n_small) {
+    const std::size_t total_bytes = static_cast<std::size_t>(large_count)
+                                  * large_blob_size;
+    const std::size_t small_count = small ? small->write_ms.size() : n_small;
+    constexpr int C = 16;  // data column width
+
+    // Returns "X" when the optional is empty; otherwise calls fn(*r).
+    auto cell = [](const std::optional<BenchResult>& r,
+                   auto fn) -> std::string {
+        return r ? fn(*r) : "X";
+    };
+
+    auto throughput = [&](const std::optional<BenchResult>& r,
+                          double BenchResult::* wall_s) -> std::string {
+        return cell(r, [&](const BenchResult& b) -> std::string {
+            const double w = b.*wall_s;
+            if (w <= 0.0) return "—";
+            return std::format("{:.1f} MiB/s",
+                               static_cast<double>(total_bytes) / w /
+                               (1024.0 * 1024.0));
+        });
+    };
+
+    auto row = [C](std::string_view label,
+                   std::string_view lw, std::string_view lr,
+                   std::string_view sw, std::string_view sr) {
+        std::println("  {:<32}  {:>{}}  {:>{}}  {:>{}}  {:>{}}",
+                     label, lw, C, lr, C, sw, C, sr, C);
+    };
+
+    // lat_row: nullopt p → min; otherwise the given percentile.
+    // Cells for skipped cases show "X".
+    auto lat_cell = [](const std::optional<BenchResult>& r,
+                       const std::vector<double> BenchResult::* vec,
+                       std::optional<double> p) -> std::string {
+        if (!r) return "X";
+        const auto& v = r.value().*vec;
+        if (v.empty()) return "X";
+        return fmt_ms(p ? percentile(v, *p) : std::ranges::min(v));
+    };
+
+    auto lat_row = [&](std::string_view label, std::optional<double> p) {
+        row(label,
+            lat_cell(large, &BenchResult::write_ms, p),
+            lat_cell(large, &BenchResult::read_ms,  p),
+            lat_cell(small, &BenchResult::write_ms, p),
+            lat_cell(small, &BenchResult::read_ms,  p));
+    };
+
+    auto max_cell = [](const std::optional<BenchResult>& r,
+                       const std::vector<double> BenchResult::* vec)
+            -> std::string {
+        if (!r) return "X";
+        const auto& v = r.value().*vec;
+        return v.empty() ? "X" : fmt_ms(std::ranges::max(v));
+    };
+
+    const std::string sep_label(32, '-');
+    const std::string sep_col(C,  '-');
+
+    std::println("\n{}", kRuler);
+    std::println("  BENCHMARK RESULTS");
+    std::println("{}", kRuler);
+    std::println("  Total payload   : {}  ({} × {} large  |  {} × {} small)",
+                 fmt_bytes(static_cast<double>(total_bytes)),
+                 fmt_count(static_cast<std::size_t>(large_count)),
+                 fmt_bytes(static_cast<double>(large_blob_size)),
+                 fmt_count(small_count),
+                 fmt_bytes(static_cast<double>(small_blob_size)));
+    std::println("");
+    row("", "-- LARGE BLOB --", "READ", "-- SMALL BLOB --", "READ");
+    row("", "WRITE", "", "WRITE", "");
+    std::println("  {}  {}  {}  {}  {}",
+                 sep_label, sep_col, sep_col, sep_col, sep_col);
+
+    row("Throughput",
+        throughput(large, &BenchResult::write_wall_s),
+        throughput(large, &BenchResult::read_wall_s),
+        throughput(small, &BenchResult::write_wall_s),
+        throughput(small, &BenchResult::read_wall_s));
+    std::println("");
+    row("Total time",
+        cell(large, [](const BenchResult& b) { return fmt_s(b.write_wall_s); }),
+        cell(large, [](const BenchResult& b) { return fmt_s(b.read_wall_s);  }),
+        cell(small, [](const BenchResult& b) { return fmt_s(b.write_wall_s); }),
+        cell(small, [](const BenchResult& b) { return fmt_s(b.read_wall_s);  }));
+    row("Op count",
+        fmt_count(static_cast<std::size_t>(large_count)),
+        fmt_count(static_cast<std::size_t>(large_count)),
+        fmt_count(small_count),
+        fmt_count(small_count));
+    std::println("");
+    std::println("  Per-op latency  "
+                 "[large = one {} blob; small = one {} CQL op]",
+                 fmt_bytes(static_cast<double>(large_blob_size)),
+                 fmt_bytes(static_cast<double>(small_blob_size)));
+    std::println("  {}  {}  {}  {}  {}",
+                 sep_label, sep_col, sep_col, sep_col, sep_col);
+    lat_row("  min", std::nullopt);
+    lat_row("  p50", 50.0);
+    lat_row("  p99", 99.0);
+    row("  max",
+        max_cell(large, &BenchResult::write_ms),
+        max_cell(large, &BenchResult::read_ms),
+        max_cell(small, &BenchResult::write_ms),
+        max_cell(small, &BenchResult::read_ms));
+    std::println("{}", kRuler);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/// All command-line / environment-variable configuration.
+struct Args {
+    std::string contact_points = "127.0.0.1"; ///< Comma-separated ScyllaDB hosts.
+    int         port           = 9042;         ///< CQL native port.
+    std::string username;                      ///< CQL username (empty = no auth).
+    std::string password;                      ///< CQL password.
+    std::string keyspace       = "blob_bench"; ///< Keyspace to create / use.
+    int         rf             = 1;            ///< Replication factor.
+    int         count          = 1000;         ///< Number of large blobs.
+    int         large_mb       = 30;           ///< Large blob size (MiB).
+    int         small_kb       = 64;           ///< Small blob size (KiB).
+    int         chunk_size_kb  = 64;           ///< Chunk size for SaltedBlobStore (KiB).
+    int         max_salt       = 100;          ///< max_salt for SaltedBlobStore.
+    int         concurrency       = 64;         ///< Async window for small-blob ops.
+    int         store_concurrency = scs::kDefaultMaxConcurrency; ///< Max in-flight futures per SaltedBlobStore call (0 = unlimited).
+    bool        skip_large     = false;        ///< Skip the large-blob benchmark.
+    bool        skip_small     = false;        ///< Skip the small-blob benchmark.
+    bool        cleanup        = false;        ///< DROP keyspace when finished.
+};
+
+[[noreturn]] void usage(int rc) {
+    std::println(
+        "Usage: benchmark [OPTIONS]\n"
+        "\n"
+        "Options:\n"
+        "  --contact-points HOSTS   Comma-separated ScyllaDB host list (default: 127.0.0.1)\n"
+        "  --port N                 CQL port (default: 9042)\n"
+        "  --username U             CQL username\n"
+        "  --password P             CQL password\n"
+        "  --keyspace KS            Keyspace name (default: blob_bench)\n"
+        "  --rf N                   Replication factor (default: 1)\n"
+        "  --count N                Number of large blobs (default: 1000)\n"
+        "  --large-mb N             Large blob size in MiB (default: 30)\n"
+        "  --small-kb N             Small blob size in KiB (default: 64)\n"
+        "  --chunk-size-kb N        Chunk size for SaltedBlobStore in KiB (default: 64)\n"
+        "  --max-salt N             max_salt for SaltedBlobStore (default: 100)\n"
+        "  --concurrency N          Async window for small-blob ops (default: 64)\n"
+        "  --store-concurrency N    Max in-flight futures per SaltedBlobStore call, 0=unlimited (default: 0)\n"
+        "  --skip-large             Skip the large-blob benchmark\n"
+        "  --skip-small             Skip the small-blob benchmark\n"
+        "  --cleanup                DROP keyspace when finished\n"
+        "  -h, --help               Print this message and exit");
+    std::exit(rc);
+}
+
+Args parse(int argc, char** argv) {
+    Args a;
+    if (const char* e = std::getenv("SCYLLA_CONTACT_POINTS")) a.contact_points = e;
+    if (const char* e = std::getenv("SCYLLA_PORT"))           a.port = std::atoi(e);
+    if (const char* e = std::getenv("SCYLLA_USERNAME"))       a.username = e;
+    if (const char* e = std::getenv("SCYLLA_PASSWORD"))       a.password = e;
+
+    auto need = [&](int& i, const char* opt) -> std::string {
+        if (i + 1 >= argc) {
+            std::println(stderr, "missing value for {}", opt);
+            usage(2);
+        }
+        return argv[++i];
+    };
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view s = argv[i];
+        if      (s == "--contact-points") a.contact_points = need(i, "--contact-points");
+        else if (s == "--port")           a.port           = std::stoi(need(i, "--port"));
+        else if (s == "--username")       a.username       = need(i, "--username");
+        else if (s == "--password")       a.password       = need(i, "--password");
+        else if (s == "--keyspace")       a.keyspace       = need(i, "--keyspace");
+        else if (s == "--rf")             a.rf             = std::stoi(need(i, "--rf"));
+        else if (s == "--count")          a.count          = std::stoi(need(i, "--count"));
+        else if (s == "--large-mb")       a.large_mb       = std::stoi(need(i, "--large-mb"));
+        else if (s == "--small-kb")       a.small_kb       = std::stoi(need(i, "--small-kb"));
+        else if (s == "--chunk-size-kb")  a.chunk_size_kb  = std::stoi(need(i, "--chunk-size-kb"));
+        else if (s == "--max-salt")       a.max_salt       = std::stoi(need(i, "--max-salt"));
+        else if (s == "--concurrency")       a.concurrency       = std::stoi(need(i, "--concurrency"));
+        else if (s == "--store-concurrency") a.store_concurrency = std::stoi(need(i, "--store-concurrency"));
+        else if (s == "--skip-large")        a.skip_large        = true;
+        else if (s == "--skip-small")     a.skip_small     = true;
+        else if (s == "--cleanup")        a.cleanup        = true;
+        else if (s == "-h" || s == "--help") usage(0);
+        else {
+            std::println(stderr, "unknown argument: {}", s);
+            usage(2);
+        }
+    }
+    return a;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    const Args a = parse(argc, argv);
+
+    const std::size_t blob_size   = static_cast<std::size_t>(a.large_mb)     * 1024uz * 1024uz;
+    const std::size_t small_size  = static_cast<std::size_t>(a.small_kb)     * 1024uz;
+    const std::size_t chunk_size  = static_cast<std::size_t>(a.chunk_size_kb) * 1024uz;
+    const std::size_t total_bytes = static_cast<std::size_t>(a.count) * blob_size;
+    const std::size_t n_small     = (total_bytes + small_size - 1uz) / small_size;
+
+    std::println("{}", kRuler);
+    std::println("  ScyllaDB  ·  Large-vs-Small Blob Benchmark");
+    std::println("{}", kRuler);
+    std::println("  Large blobs  : {} × {} MiB  =  {} total",
+                 fmt_count(static_cast<std::size_t>(a.count)), a.large_mb,
+                 fmt_bytes(static_cast<double>(total_bytes)));
+    std::println("  Small blobs  : {} × {} KiB  ≈  {} total",
+                 fmt_count(n_small), a.small_kb,
+                 fmt_bytes(static_cast<double>(n_small * small_size)));
+    std::println("  Chunk size   : {} KiB   max_salt={}   concurrency={}   store-concurrency={}",
+                 a.chunk_size_kb, a.max_salt, a.concurrency,
+                 a.store_concurrency == 0 ? "unlimited" : std::to_string(a.store_concurrency));
+    std::println("  ScyllaDB     : {}:{}   keyspace={}   rf={}",
+                 a.contact_points, a.port, a.keyspace, a.rf);
+    std::println("{}", kRuler);
+
+    CassCluster* cluster = cass_cluster_new();
+    CassSession* session = cass_session_new();
+    cass_cluster_set_contact_points(cluster, a.contact_points.c_str());
+    cass_cluster_set_port(cluster, a.port);
+    cass_cluster_set_protocol_version(cluster, 4);
+    cass_cluster_set_token_aware_routing(cluster, cass_true);
+    if (!a.username.empty())
+        cass_cluster_set_credentials(cluster,
+                                     a.username.c_str(), a.password.c_str());
+
+    int rc = 0;
+    {
+        CassFuture* cf = cass_session_connect(session, cluster);
+        cass_future_wait(cf);
+        if (cass_future_error_code(cf) != CASS_OK) {
+            const char* msg     = nullptr;
+            std::size_t msg_len = 0uz;
+            cass_future_error_message(cf, &msg, &msg_len);
+            std::println(stderr, "connect failed: {}",
+                         std::string_view{msg, msg_len});
+            rc = 1;
+        }
+        cass_future_free(cf);
+    }
+
+    if (rc == 0) {
+        try {
+            execute_simple(session, std::format(
+                "CREATE KEYSPACE IF NOT EXISTS {} WITH replication = "
+                "{{'class':'SimpleStrategy','replication_factor':{}}}",
+                a.keyspace, a.rf));
+
+            std::print("\n  Generating payload buffers...");
+            std::fflush(stdout);
+            const scs::Bytes large_payload = make_payload(blob_size);
+            const auto       small_payload =
+                std::span{large_payload}.first(small_size);
+            std::println(" done.");
+
+            std::optional<BenchResult> large_res;
+            std::optional<BenchResult> small_res;
+
+            if (!a.skip_large) {
+                scs::SaltedBlobStore store(session, a.keyspace, "salted_blobs");
+                store.create_schema(a.rf);
+                large_res = bench_large(store, a.count, blob_size,
+                                        a.max_salt, chunk_size, large_payload,
+                                        a.store_concurrency);
+            }
+
+            if (!a.skip_small) {
+                small_res = bench_small(session, a.keyspace, total_bytes,
+                                        small_size, small_payload,
+                                        a.concurrency);
+            }
+
+            report(large_res, small_res, blob_size, a.count, small_size, n_small);
+
+            if (a.cleanup) {
+                std::print("\n  Dropping keyspace {} ...", a.keyspace);
+                std::fflush(stdout);
+                execute_simple(session,
+                               "DROP KEYSPACE IF EXISTS " + a.keyspace);
+                std::println(" done.");
+            }
+        } catch (const std::exception& ex) {
+            std::println(stderr, "Benchmark failed: {}", ex.what());
+            rc = 1;
+        }
+    }
+
+    CassFuture* close_fut = cass_session_close(session);
+    cass_future_wait(close_fut);
+    cass_future_free(close_fut);
+    cass_session_free(session);
+    cass_cluster_free(cluster);
+    return rc;
+}

--- a/chunking-large-cells/cpp/demo.cpp
+++ b/chunking-large-cells/cpp/demo.cpp
@@ -1,0 +1,361 @@
+// End-to-end demo of the modified salting technique against ScyllaDB.
+//
+// Mirrors the Python demo in ../python/demo.py: writes three blobs of
+// different sizes following the hybrid policy from the blog post, verifies
+// each round-trip, and prints how the blob is laid out across salted
+// partitions.
+
+#include "salted_blob_store.h"
+
+#include <cassandra.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <format>
+#include <print>
+#include <random>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <algorithm>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Test-data helpers
+// ---------------------------------------------------------------------------
+
+/// Generates a deterministic, pseudo-random byte buffer of exactly @p size bytes.
+///
+/// The PRNG is seeded from @p seed_str via std::seed_seq, so the same
+/// (seed, size) pair always produces identical bytes.  This lets the demo
+/// verify round-trips without storing an expected value separately.
+///
+/// @param seed_str  Human-readable seed string (e.g. "large-key:seed").
+/// @param size      Number of bytes to generate.
+/// @return A Bytes vector of length @p size filled with pseudo-random data.
+scs::Bytes deterministic_blob(std::string_view seed_str, std::size_t size) {
+    std::seed_seq       seq(seed_str.begin(), seed_str.end());
+    std::mt19937_64     rng(seq);
+    scs::Bytes          out(size);
+    std::size_t         i = 0uz;
+    // Fill 8 bytes at a time for efficiency; the final partial word is handled
+    // separately to avoid writing past the end of the buffer.
+    while (i + 8uz <= size) {
+        const std::uint64_t v = rng();
+        std::memcpy(out.data() + i, &v, 8);
+        i += 8uz;
+    }
+    // (size - i) is guaranteed to be less than 8 here.
+    if (i < size) {
+        const std::uint64_t v = rng();
+        std::memcpy(out.data() + i, &v, size - i);
+    }
+    return out;
+}
+
+/// Computes a 64-bit FNV-1a hash of @p v.
+///
+/// FNV-1a is not cryptographically secure, but is fast and sufficient for a
+/// demo fingerprint that confirms the round-trip did not corrupt the data.
+/// The hash is printed as a hex digest in the output.
+///
+/// @param v  Byte span to hash.
+/// @return   64-bit digest.
+template <typename T>
+concept uint8_range = std::ranges::range<T> &&
+                      std::same_as<std::ranges::range_value_t<T>, std::uint8_t>;
+template <uint8_range T>
+std::uint64_t fnv1a64(T&& v) {
+    std::uint64_t h = 0xcbf29ce484222325ULL;
+    for (std::uint8_t b : v) {
+        h ^= b;
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+/// Formats a raw byte count as a human-readable IEC string (B / KiB / MiB …).
+///
+/// The value is divided by 1024 until it falls below 1024 or the largest
+/// unit is reached.  The result is right-aligned in a 7-character field with
+/// 2 decimal places, e.g. @c "   4.00 KiB".
+///
+/// @param n  Byte count to format.
+/// @return   Formatted string, e.g. @c "  64.00 KiB".
+std::string fmt_bytes(double n) {
+    static constexpr std::array<std::string_view, 5> units{
+        "B", "KiB", "MiB", "GiB", "TiB"};
+    std::size_t u = 0uz;
+    while (n >= 1024.0 && u + 1uz < units.size())
+        { n /= 1024.0; ++u; }
+    return std::format("{:7.2f} {}", n, units[u]);
+}
+
+/// Reinterprets the bytes of a @c string_view as a span of @c uint8_t.
+///
+/// Avoids constructing a @c std::vector<uint8_t> just to pass a string literal
+/// as a SaltedBlobStore key.  The returned span's lifetime is tied to @p s.
+///
+/// @param s  Source string view.
+/// @return   Non-owning span over the same bytes.
+std::span<const std::uint8_t> as_key(std::string_view s) {
+    return {reinterpret_cast<const std::uint8_t*>(s.data()), s.size()};
+}
+
+/// Returns the number of milliseconds elapsed since @p t0 using a monotonic clock.
+///
+/// @param t0  Start time obtained from std::chrono::steady_clock::now().
+/// @return    Elapsed duration in milliseconds as a double.
+double elapsed_ms(std::chrono::steady_clock::time_point t0) {
+    return std::chrono::duration<double, std::milli>(
+               std::chrono::steady_clock::now() - t0).count();
+}
+
+// ---------------------------------------------------------------------------
+// Demo runner
+// ---------------------------------------------------------------------------
+
+/// Exercises a single write → read → verify → describe cycle.
+///
+/// Generates a deterministic blob of @p size bytes, writes it to @p store with
+/// the supplied salting parameters, reads it back, and verifies content
+/// integrity via FNV-1a fingerprinting.  Also calls describe() to show how the
+/// blob is spread across partitions.  Throws on any mismatch or driver error.
+///
+/// @param store       SaltedBlobStore instance to operate on.
+/// @param name        Human-readable label printed as the section heading.
+/// @param key_str     CQL blob key (passed as a string-view-derived span).
+/// @param size        Blob size in bytes.
+/// @param max_salt    Maximum salt cardinality for the write call.
+/// @param chunk_size  Chunk size in bytes for the write call.
+/// @throws std::runtime_error if the round-trip fingerprint does not match.
+void run_case(scs::SaltedBlobStore& store,
+              std::string_view       name,
+              std::string_view       key_str,
+              std::size_t            size,
+              int                    max_salt,
+              std::size_t            chunk_size,
+              int                    max_concurrency) {
+    const auto          key    = as_key(key_str);
+    const scs::Bytes    blob   = deterministic_blob(
+                                     std::format("{}:seed", key_str), size);
+    const std::uint64_t fp_in  = fnv1a64(blob);
+
+    std::println("\n=== {} ===", name);
+    std::println("  key        : {}", key_str);
+    std::println("  size       : {}", fmt_bytes(static_cast<double>(blob.size())));
+    std::println("  max_salt   : {}", max_salt);
+    std::println("  chunk_size : {}", fmt_bytes(static_cast<double>(chunk_size)));
+    std::println("  fnv1a(in)  : 0x{:016x}", fp_in);
+
+    auto t0 = std::chrono::steady_clock::now();
+    store.write(key, blob, max_salt, chunk_size,
+                scs::kDefaultMaxBatchBytes, max_concurrency);
+    const double t_write = elapsed_ms(t0);
+
+    t0 = std::chrono::steady_clock::now();
+    auto out = store.read(key, max_concurrency);
+    const double t_read = elapsed_ms(t0);
+
+    if (!out) throw std::runtime_error("blob unexpectedly missing after write");
+    const std::uint64_t fp_out = fnv1a64((*out | std::views::join));
+    std::println("  fnv1a(out) : 0x{:016x}", fp_out);
+    std::println("  write      : {:8.1f} ms", t_write);
+    std::println("  read       : {:8.1f} ms", t_read);
+    if (!std::ranges::equal((*out | std::views::join), blob)) throw std::runtime_error("round-trip digest mismatch");
+    std::println("  round-trip : OK");
+
+    // Print the partition layout, capping the per-partition list at 5 rows to
+    // keep output manageable for highly-salted blobs.
+    if (auto layout = store.describe(key, max_concurrency)) {
+        std::println("  layout     : total_chunks={}, salt_cardinality={}, stored_bytes={}",
+                     layout->total_chunks, layout->salt_cardinality,
+                     fmt_bytes(static_cast<double>(layout->total_bytes())));
+        constexpr std::size_t kMaxShown = 5uz;
+        const std::size_t shown = std::min(kMaxShown, layout->partitions.size());
+        for (const auto& p : layout->partitions | std::views::take(shown))
+            std::println("    salt={:3d}  rows={:4}  bytes={}",
+                         p.salt, p.rows,
+                         fmt_bytes(static_cast<double>(p.bytes)));
+        if (layout->partitions.size() > shown)
+            std::println("    ... ({} more salted partitions)",
+                         layout->partitions.size() - shown);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+/// Holds all command-line (and environment-variable) configuration for the demo.
+struct Args {
+    std::string contact_points = "127.0.0.1";  ///< Comma-separated list of ScyllaDB contact points.
+    int         port           = 9042;          ///< Native CQL port.
+    std::string username;                       ///< CQL username (empty = no authentication).
+    std::string password;                       ///< CQL password (empty = no authentication).
+    std::string keyspace       = "salted_blob_demo"; ///< Keyspace to create / use.
+    std::string table          = "salted_blobs";     ///< Table to create / use within the keyspace.
+    int         rf             = 1;             ///< Replication factor for CREATE KEYSPACE.
+    int         large_mb       = 8;             ///< Size in MiB for the large-blob test case.
+    int         max_concurrency = scs::kDefaultMaxConcurrency; ///< Max in-flight CQL futures per store call (0 = unlimited).
+    bool        cleanup        = false;         ///< If true, DROP KEYSPACE after all test cases.
+};
+
+/// Prints a brief usage message to stdout and exits with @p rc.
+/// Declared [[noreturn]] because std::exit never returns.
+[[noreturn]] void usage(int rc) {
+    std::println(
+        "Usage: demo [--contact-points HOSTS] [--port N] [--username U] [--password P]\n"
+        "            [--keyspace KS] [--table T] [--rf N] [--large-mb N]\n"
+        "            [--max-concurrency N] [--cleanup]");
+    std::exit(rc);
+}
+
+/// Parses command-line arguments into an Args struct.
+///
+/// Environment variables are read first as defaults; CLI flags override them.
+/// Recognised environment variables:
+///   - SCYLLA_CONTACT_POINTS
+///   - SCYLLA_PORT
+///   - SCYLLA_USERNAME
+///   - SCYLLA_PASSWORD
+///
+/// @param argc  Argument count from main.
+/// @param argv  Argument vector from main.
+/// @return      Fully populated Args.
+/// @note Calls usage(2) and exits on unknown flags or missing values.
+Args parse(int argc, char** argv) {
+    Args a;
+    if (const char* e = std::getenv("SCYLLA_CONTACT_POINTS")) a.contact_points = e;
+    if (const char* e = std::getenv("SCYLLA_PORT"))           a.port = std::atoi(e);
+    if (const char* e = std::getenv("SCYLLA_USERNAME"))       a.username = e;
+    if (const char* e = std::getenv("SCYLLA_PASSWORD"))       a.password = e;
+
+    // Retrieves the value for the next argv token; exits with usage(2) if none.
+    auto need = [&](int& i, const char* opt) -> std::string {
+        if (i + 1 >= argc) {
+            std::println(stderr, "missing value for {}", opt);
+            usage(2);
+        }
+        return argv[++i];
+    };
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view s = argv[i];
+        if      (s == "--contact-points") a.contact_points = need(i, "--contact-points");
+        else if (s == "--port")           a.port           = std::stoi(need(i, "--port"));
+        else if (s == "--username")       a.username       = need(i, "--username");
+        else if (s == "--password")       a.password       = need(i, "--password");
+        else if (s == "--keyspace")       a.keyspace       = need(i, "--keyspace");
+        else if (s == "--table")          a.table          = need(i, "--table");
+        else if (s == "--rf")             a.rf             = std::stoi(need(i, "--rf"));
+        else if (s == "--large-mb")        a.large_mb        = std::stoi(need(i, "--large-mb"));
+        else if (s == "--max-concurrency") a.max_concurrency = std::stoi(need(i, "--max-concurrency"));
+        else if (s == "--cleanup")         a.cleanup         = true;
+        else if (s == "-h" || s == "--help") usage(0);
+        else {
+            std::println(stderr, "unknown argument: {}", s);
+            usage(2);
+        }
+    }
+    return a;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Sets up a CassCluster and CassSession, creates the schema, and runs
+/// three test cases (small / medium / large blob) plus a missing-key probe
+/// and an erase verification.
+///
+/// Returns 0 on success or 1 if the connection fails or any test case throws.
+/// The CassSession and CassCluster are freed unconditionally before exit so
+/// the driver can flush any pending work.
+int main(int argc, char** argv) {
+    const Args args = parse(argc, argv);
+
+    CassCluster* cluster = cass_cluster_new();
+    CassSession* session = cass_session_new();
+    cass_cluster_set_contact_points(cluster, args.contact_points.c_str());
+    cass_cluster_set_port(cluster, args.port);
+    // CQL native protocol v4 — required for Scylla shard-aware routing.
+    cass_cluster_set_protocol_version(cluster, 4);
+    // Token-aware routing sends each request directly to the owning shard,
+    // avoiding an extra coordinator hop.
+    cass_cluster_set_token_aware_routing(cluster, cass_true);
+    if (!args.username.empty())
+        cass_cluster_set_credentials(cluster, args.username.c_str(), args.password.c_str());
+
+    int rc_main = 0;
+    CassFuture* connect = cass_session_connect(session, cluster);
+    cass_future_wait(connect);
+    if (cass_future_error_code(connect) != CASS_OK) {
+        const char* msg     = nullptr;
+        std::size_t msg_len = 0uz;
+        cass_future_error_message(connect, &msg, &msg_len);
+        std::println(stderr, "connect failed: {}", std::string_view{msg, msg_len});
+        rc_main = 1;
+    }
+    cass_future_free(connect);
+
+    if (rc_main == 0) {
+        try {
+            scs::SaltedBlobStore store(session, args.keyspace, args.table);
+            store.create_schema(args.rf);
+
+            // Small blob: fits in a single chunk, no salting required.
+            run_case(store, "small blob (no chunking)",
+                     "small-key",  2uz * 1024,   1,   4096uz, args.max_concurrency);
+            // Medium blob: a handful of salts demonstrates the distribution.
+            run_case(store, "medium blob (a few salts)",
+                     "medium-key", 256uz * 1024, 8,   4096uz, args.max_concurrency);
+            // Large blob: high salt cardinality with larger chunks to reduce row count.
+            run_case(store,
+                     std::format("large blob (high salting, {} MiB)", args.large_mb),
+                     "large-key",
+                     static_cast<std::size_t>(args.large_mb) * 1024uz * 1024uz,
+                     100, 64uz * 1024, args.max_concurrency);
+
+            // Verify that a lookup for an absent key returns std::nullopt.
+            std::println("\n=== missing key ===");
+            const auto missing = store.read(as_key("does-not-exist"));
+            std::println("  read(missing) -> {}",
+                         missing ? "<some bytes>" : "<nullopt>");
+
+            // Verify that erase makes a key unreadable.
+            std::println("\n=== delete medium-key ===");
+            store.erase(as_key("medium-key"), args.max_concurrency);
+            const auto after = store.read(as_key("medium-key"));
+            std::println("  read(medium-key) -> {}",
+                         after ? "<some bytes>" : "<nullopt>");
+
+            if (args.cleanup) {
+                std::println("\nCleaning up keyspace...");
+                store.drop_schema();
+            }
+        } catch (const std::exception& ex) {
+            std::println(stderr, "Demo failed: {}", ex.what());
+            rc_main = 1;
+        }
+    }
+
+    // Always close the session gracefully so the driver can drain in-flight
+    // requests and free its internal thread pool.
+    CassFuture* close = cass_session_close(session);
+    cass_future_wait(close);
+    cass_future_free(close);
+    cass_session_free(session);
+    cass_cluster_free(cluster);
+    return rc_main;
+}

--- a/chunking-large-cells/cpp/salted_blob_store.cpp
+++ b/chunking-large-cells/cpp/salted_blob_store.cpp
@@ -1,0 +1,611 @@
+#include "salted_blob_store.h"
+
+#include <algorithm>
+#include <atomic>
+#include <format>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <ranges>
+#include <semaphore>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace scs {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// RAII wrappers for driver objects
+//
+// A single stateless deleter parameterised on the C-linkage free function
+// (C++20 auto NTTP) replaces five near-identical typedefs and wrap() helpers.
+// Because the deleter is empty, the resulting CassUnique<T,Free> has the same
+// size as a raw pointer (no extra storage for a function-pointer deleter).
+// ---------------------------------------------------------------------------
+
+template <auto Free>
+struct CassDeleter {
+    template <typename T> void operator()(T* p) const noexcept { Free(p); }
+};
+
+template <typename T, auto Free>
+using CassUnique = std::unique_ptr<T, CassDeleter<Free>>;
+
+using FuturePtr    = CassUnique<CassFuture,       cass_future_free>;
+using ResultPtr    = CassUnique<const CassResult, cass_result_free>;
+using IteratorPtr  = CassUnique<CassIterator,     cass_iterator_free>;
+using StatementPtr = CassUnique<CassStatement,    cass_statement_free>;
+using BatchPtr     = CassUnique<CassBatch,        cass_batch_free>;
+
+// ---------------------------------------------------------------------------
+// Error helpers
+// ---------------------------------------------------------------------------
+
+/// Extracts the driver error message from @p f and throws std::runtime_error.
+/// @p where is prepended to the message to identify the call site.
+/// Declared [[noreturn]] so the compiler knows callers need not handle a
+/// normal return path.
+[[noreturn]] void throw_future_error(CassFuture* f, const std::string& where) {
+    const char* msg     = nullptr;
+    std::size_t msg_len = 0;
+    cass_future_error_message(f, &msg, &msg_len);
+    throw std::runtime_error(where + ": " + std::string(msg, msg_len));
+}
+
+/// Checks @p f for a driver error without waiting.  If the future already
+/// has an error code set, delegates to throw_future_error.  Call this only
+/// after the future is known to be complete (i.e., after cass_future_wait).
+void check(CassFuture* f, const std::string& where) {
+    if (cass_future_error_code(f) != CASS_OK) [[unlikely]]
+        throw_future_error(f, where);
+}
+
+/// Blocks until @p f completes, then checks its error code via check().
+/// This is the synchronous "fire and wait" pattern used for DDL and
+/// single-statement reads.
+void wait_check(CassFuture* f, const std::string& where) {
+    cass_future_wait(f);
+    check(f, where);
+}
+
+// ---------------------------------------------------------------------------
+// Driver utilities
+// ---------------------------------------------------------------------------
+
+/// Prepares a single CQL statement on @p session and returns the resulting
+/// CassPrepared handle (caller owns it).  Blocks until the PREPARE round-trip
+/// completes.
+/// @throws std::runtime_error if the PREPARE fails.
+const CassPrepared* prepare_one(CassSession* session, const std::string& cql) {
+    FuturePtr fut{cass_session_prepare(session, cql.c_str())};
+    wait_check(fut.get(), "PREPARE " + cql);
+    return cass_future_get_prepared(fut.get());
+}
+
+/// Reads a CQL int column value and returns it as cass_int32_t.
+/// If the value is null or of the wrong type, the driver leaves @c out at 0.
+cass_int32_t get_int32(const CassValue* v) {
+    cass_int32_t out = 0;
+    cass_value_get_int32(v, &out);
+    return out;
+}
+
+/// Binds a byte-array value to parameter @p idx of @p stmt.
+///
+/// The CQL driver's bind function requires a non-null pointer even for
+/// zero-length blobs, so a stable dummy byte is provided in that case.
+/// The data is copied by the driver, so the span need not outlive the call.
+void bind_blob(CassStatement* stmt, std::size_t idx,
+               std::span<const std::uint8_t> data) {
+    static constexpr std::uint8_t empty = 0;
+    cass_statement_bind_bytes(stmt, idx,
+                              data.empty() ? &empty : data.data(),
+                              data.size());
+}
+
+// ---------------------------------------------------------------------------
+// Sliding-window callback infrastructure
+//
+// When max_concurrency > 0, write / read / erase keep exactly that many CQL
+// futures in-flight at once.  The producer acquires a semaphore permit before
+// issuing each future; the completion callback releases the permit.  This lets
+// any completing future unblock the producer immediately, regardless of
+// submission order, giving a true sliding window.
+// ---------------------------------------------------------------------------
+
+/// Shared error accumulator written by callbacks, read by the producer after
+/// the drain phase.  The first error message is preserved; all subsequent
+/// errors only increment the count.
+struct CallbackErr {
+    std::atomic<int> count{0};
+    std::mutex       mu;
+    std::string      first;
+
+    void record(std::string_view msg) noexcept {
+        std::lock_guard lk{mu};
+        if (first.empty()) first.assign(msg);
+        count.fetch_add(1, std::memory_order_relaxed);
+    }
+    bool any() const noexcept { return count.load(std::memory_order_acquire) > 0; }
+    std::string take() { std::lock_guard lk{mu}; return std::exchange(first, {}); }
+};
+
+struct KeyMeta {
+    cass_int32_t total_chunks;
+    cass_int32_t salt_cardinality;
+
+    KeyMeta(cass_int32_t total_chunks_, cass_int32_t salt_cardinality_)
+        : total_chunks(total_chunks_), salt_cardinality(salt_cardinality_)
+    {
+        if (total_chunks < 0 || salt_cardinality <= 0)
+            throw std::runtime_error(
+                std::format("invalid metadata: total_chunks={}, salt_cardinality={}", total_chunks, salt_cardinality));
+    }
+};
+
+using FutureTask = std::function<FuturePtr()>;
+using ResultHandler = std::function<void(const CassResult*)>;
+using PartitionHandler = std::function<void(int salt, const CassResult*)>;
+
+struct AsyncTask {
+    FutureTask      submit;
+    ResultHandler   handle;  ///< Empty for void futures (write / erase).
+};
+
+struct AsyncCtx {
+    ResultHandler               handle;
+    std::counting_semaphore<>*  slots;
+    CallbackErr*                err;
+};
+
+/// Completion callback for async tasks (write, erase, partition SELECT).
+/// Invoked on a driver I/O thread; must be noexcept.
+void on_async_done(CassFuture* fut, void* data) noexcept {
+    auto* ctx = static_cast<AsyncCtx*>(data);
+    if (cass_future_error_code(fut) != CASS_OK) [[unlikely]] {
+        const char* msg = nullptr; std::size_t mlen = 0;
+        cass_future_error_message(fut, &msg, &mlen);
+        ctx->err->record({msg, mlen});
+    } else if (ctx->handle) {
+        ResultPtr res{cass_future_get_result(fut)};
+        try {
+            ctx->handle(res.get());
+        } catch (const std::exception& e) {
+            ctx->err->record(e.what());
+        } catch (...) {
+            ctx->err->record("unknown exception in result handler");
+        }
+    }
+    auto* const slots = ctx->slots;
+    cass_future_free(fut);
+    delete ctx;
+    slots->release();
+}
+
+/// Blocks until all @p concurrency permits have been re-acquired — i.e. every
+/// outstanding callback has released its slot — then throws if any error was
+/// recorded.
+void drain_and_check(std::counting_semaphore<>& slots, int concurrency,
+                     CallbackErr& err, std::string_view where) {
+    for (int i = 0; i < concurrency; ++i) slots.acquire();
+    if (err.any()) [[unlikely]]
+        throw std::runtime_error(std::string(where) + ": " + err.take());
+}
+
+/// Runs async tasks; dispatches results to @c handle when set (partition SELECT).
+void run_async_tasks(int max_concurrency, const std::vector<AsyncTask>& tasks,
+                     std::string_view where) {
+    if (tasks.empty()) return;
+    if (max_concurrency <= 0) {
+        std::vector<FuturePtr> futs;
+        futs.reserve(tasks.size());
+        for (const auto& task : tasks) futs.push_back(task.submit());
+        for (std::size_t i = 0; i < futs.size(); ++i) {
+            wait_check(futs[i].get(), std::string(where));
+            if (tasks[i].handle) {
+                ResultPtr res{cass_future_get_result(futs[i].get())};
+                tasks[i].handle(res.get());
+            }
+        }
+        return;
+    }
+    std::counting_semaphore<> slots(max_concurrency);
+    CallbackErr               err;
+    for (const auto& task : tasks) {
+        slots.acquire();
+        if (err.any()) [[unlikely]] { slots.release(); break; }
+        CassFuture* fut = task.submit().release();
+        auto* ctx       = new AsyncCtx{task.handle, &slots, &err};
+        if (cass_future_set_callback(fut, &on_async_done, ctx) != CASS_OK) [[unlikely]] {
+            delete ctx;
+            cass_future_free(fut);
+            slots.release();
+            err.record("cass_future_set_callback failed");
+            break;
+        }
+    }
+    drain_and_check(slots, max_concurrency, err, where);
+}
+
+std::optional<KeyMeta> fetch_meta(CassSession* session, const CassPrepared* select_meta,
+                                  std::span<const std::uint8_t> key,
+                                  std::string_view where) {
+    StatementPtr meta_stmt{cass_prepared_bind(select_meta)};
+    bind_blob(meta_stmt.get(), 0, key);
+    FuturePtr meta_fut{cass_session_execute(session, meta_stmt.get())};
+    wait_check(meta_fut.get(), std::string(where));
+    ResultPtr      meta_res{cass_future_get_result(meta_fut.get())};
+    const CassRow* meta_row = cass_result_first_row(meta_res.get());
+    if (!meta_row) return std::nullopt;
+    return KeyMeta(get_int32(cass_row_get_column(meta_row, 0)), get_int32(cass_row_get_column(meta_row, 1)));
+}
+
+std::vector<AsyncTask> partition_select_tasks(
+    CassSession* session, const CassPrepared* select_partition,
+    std::span<const std::uint8_t> key, int salt_count, const PartitionHandler& on_partition) {
+    std::vector<AsyncTask> tasks;
+    if (salt_count <= 0) return tasks;
+    tasks.reserve(static_cast<std::size_t>(salt_count));
+    for (int s : std::views::iota(0, salt_count)) {
+        tasks.push_back({
+            .submit = [session, select_partition, key, s] {
+                StatementPtr stmt{cass_prepared_bind(select_partition)};
+                bind_blob(stmt.get(), 0, key);
+                cass_statement_bind_int32(stmt.get(), 1, s);
+                return FuturePtr{cass_session_execute(session, stmt.get())};
+            },
+            .handle = [on_partition, s](const CassResult* res) { on_partition(s, res); },
+        });
+    }
+    return tasks;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// BlobLayout
+// ---------------------------------------------------------------------------
+
+/// Sums the @c bytes field of every PartitionInfo using a C++23 ranges pipeline:
+///   - views::transform extracts the scalar member via pointer-to-member
+///   - ranges::fold_left reduces with std::plus (replaces std::accumulate)
+std::size_t BlobLayout::total_bytes() const noexcept {
+    return std::ranges::fold_left(
+        partitions | std::views::transform(&PartitionInfo::bytes),
+        0uz, std::plus{});
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore — lifecycle
+// ---------------------------------------------------------------------------
+
+SaltedBlobStore::SaltedBlobStore(CassSession* session, std::string keyspace, std::string table)
+    : session_(session), keyspace_(std::move(keyspace)), table_(std::move(table)) {}
+
+SaltedBlobStore::~SaltedBlobStore() {
+    release_prepared_();
+}
+
+/// Frees each non-null CassPrepared handle and resets the pointer to nullptr.
+/// Called from the destructor and from drop_schema() so that the object can be
+/// reused after the schema is recreated.
+void SaltedBlobStore::release_prepared_() {
+    if (p_insert_)           { cass_prepared_free(p_insert_);           p_insert_ = nullptr; }
+    if (p_select_meta_)      { cass_prepared_free(p_select_meta_);      p_select_meta_ = nullptr; }
+    if (p_select_partition_) { cass_prepared_free(p_select_partition_); p_select_partition_ = nullptr; }
+    if (p_delete_partition_) { cass_prepared_free(p_delete_partition_); p_delete_partition_ = nullptr; }
+}
+
+/// Constructs a zero-parameter statement from @p cql, executes it
+/// synchronously, and waits for the result.  Used for DDL (CREATE / DROP)
+/// where no bound values are needed.
+void SaltedBlobStore::execute_simple_(const std::string& cql) {
+    StatementPtr stmt{cass_statement_new(cql.c_str(), 0)};
+    FuturePtr    fut{cass_session_execute(session_, stmt.get())};
+    wait_check(fut.get(), cql);
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore — schema management
+// ---------------------------------------------------------------------------
+
+/// Issues CREATE KEYSPACE IF NOT EXISTS and CREATE TABLE IF NOT EXISTS, then
+/// calls prepare_() to ready the driver-side prepared statements.
+/// @p rf is forwarded into the SimpleStrategy replication option.
+void SaltedBlobStore::create_schema(int rf) {
+    execute_simple_(std::format(
+        "CREATE KEYSPACE IF NOT EXISTS {} "
+        "WITH replication = {{'class':'SimpleStrategy','replication_factor':{}}}",
+        keyspace_, rf));
+    execute_simple_(std::format(
+        "CREATE TABLE IF NOT EXISTS {}.{}"
+        " (key blob, salt int, chunk_id int, chunk blob,"
+        "  total_chunks int, salt_cardinality int,"
+        "  PRIMARY KEY ((key, salt), chunk_id))",
+        keyspace_, table_));
+    prepare_();
+}
+
+/// Drops the entire keyspace unconditionally and releases prepared statements
+/// so this object can be pointed at a freshly created schema.
+void SaltedBlobStore::drop_schema() {
+    execute_simple_("DROP KEYSPACE IF EXISTS " + keyspace_);
+    release_prepared_();
+}
+
+/// Prepares the four CQL statements used by write / read / erase / describe.
+/// Guards against double-preparation with an early-return when p_insert_ is
+/// already set — all four are prepared atomically, so checking one is enough.
+void SaltedBlobStore::prepare_() {
+    if (p_insert_) return;
+    const std::string ks_t = std::format("{}.{}", keyspace_, table_);
+    p_insert_ = prepare_one(session_, std::format(
+        "INSERT INTO {} (key, salt, chunk_id, chunk, total_chunks, salt_cardinality)"
+        " VALUES (?, ?, ?, ?, ?, ?)", ks_t));
+    p_select_meta_ = prepare_one(session_, std::format(
+        "SELECT total_chunks, salt_cardinality FROM {}"
+        " WHERE key = ? AND salt = 0 AND chunk_id = 0", ks_t));
+    p_select_partition_ = prepare_one(session_, std::format(
+        "SELECT chunk_id, chunk FROM {} WHERE key = ? AND salt = ?", ks_t));
+    p_delete_partition_ = prepare_one(session_, std::format(
+        "DELETE FROM {} WHERE key = ? AND salt = ?", ks_t));
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore::write
+// ---------------------------------------------------------------------------
+
+/// Splits @p blob into @p chunk_size byte pieces and distributes them across
+/// up to @p max_salt CQL partitions identified by (key, salt).
+///
+/// Algorithm:
+///   1. Empty blob: write a single sentinel row at (salt=0, chunk_id=0) with
+///      total_chunks=0, salt_cardinality=1, and return.
+///   2. Non-empty blob: compute num_chunks = ceil(blob.size / chunk_size) and
+///      sc = min(num_chunks, max_salt).
+///   3. Assign each chunk_id to salt = chunk_id % sc, giving a balanced
+///      distribution.
+///   4. For each salt, build UNLOGGED batches of INSERT statements, flushing
+///      whenever the accumulated payload would exceed max_batch_bytes.
+///   5. All batch futures are collected first, then awaited together, so
+///      partitions are written in parallel.
+///
+/// The sentinel row is always at (salt=0, chunk_id=0) and carries
+/// total_chunks and salt_cardinality for later reads.
+void SaltedBlobStore::write(std::span<const std::uint8_t> key,
+                            std::span<const std::uint8_t> blob,
+                            int         max_salt,
+                            std::size_t chunk_size,
+                            std::size_t max_batch_bytes,
+                            int         max_concurrency) {
+    if (max_salt < 1)              throw std::invalid_argument("max_salt must be >= 1");
+    if (chunk_size < 1)            throw std::invalid_argument("chunk_size must be >= 1");
+    if (max_batch_bytes < 1)       throw std::invalid_argument("max_batch_bytes must be >= 1");
+    if (max_concurrency < 0)       throw std::invalid_argument("max_concurrency must be >= 0");
+    if (max_batch_bytes < chunk_size)
+        throw std::invalid_argument("max_batch_bytes must be >= chunk_size");
+    prepare_();
+
+    if (blob.empty()) {
+        StatementPtr stmt{cass_prepared_bind(p_insert_)};
+        bind_blob(stmt.get(), 0, key);
+        cass_statement_bind_int32(stmt.get(), 1, 0);
+        cass_statement_bind_int32(stmt.get(), 2, 0);
+        bind_blob(stmt.get(), 3, {});
+        cass_statement_bind_int32(stmt.get(), 4, 0);
+        cass_statement_bind_int32(stmt.get(), 5, 1);
+        FuturePtr fut{cass_session_execute(session_, stmt.get())};
+        wait_check(fut.get(), "INSERT sentinel (empty blob)");
+        return;
+    }
+
+    const std::size_t num_chunks = (blob.size() + chunk_size - 1uz) / chunk_size;
+    const int sc = static_cast<int>(
+        std::min(num_chunks, static_cast<std::size_t>(max_salt)));
+
+    // groups[salt] holds all chunk_ids assigned to that salt partition,
+    // built with a ranges pipeline that round-robins chunk ids across salts.
+    std::vector<std::vector<int>> groups(sc);
+    for (int cid : std::views::iota(0, static_cast<int>(num_chunks)))
+        groups[cid % sc].push_back(cid);
+
+    auto chunk_view = [&](int cid) -> std::span<const std::uint8_t> {
+        const std::size_t off = static_cast<std::size_t>(cid) * chunk_size;
+        return blob.subspan(off, std::min(chunk_size, blob.size() - off));
+    };
+
+    std::vector<AsyncTask> tasks;
+    for (int salt : std::views::iota(0, sc)) {
+        BatchPtr    batch{cass_batch_new(CASS_BATCH_TYPE_UNLOGGED)};
+        std::size_t batch_bytes    = 0uz;
+        bool        batch_has_rows = false;
+
+        for (int cid : groups[salt]) {
+            const auto chunk = chunk_view(cid);
+            if (batch_has_rows && batch_bytes + chunk.size() > max_batch_bytes) {
+                // This is needed because FutureTask is an std::function and it has to be copyable,
+                // which std::unique_ptr isn't.
+                auto shared_batch = std::shared_ptr<CassBatch>(batch.release(), cass_batch_free);
+                tasks.push_back({
+                    .submit = [session = session_, shared_batch] {
+                        return FuturePtr{cass_session_execute_batch(session, shared_batch.get())};
+                    },
+                });
+                batch          = BatchPtr{cass_batch_new(CASS_BATCH_TYPE_UNLOGGED)};
+                batch_bytes    = 0uz;
+                batch_has_rows = false;
+            }
+            StatementPtr stmt{cass_prepared_bind(p_insert_)};
+            bind_blob(stmt.get(), 0, key);
+            cass_statement_bind_int32(stmt.get(), 1, salt);
+            cass_statement_bind_int32(stmt.get(), 2, cid);
+            bind_blob(stmt.get(), 3, chunk);
+            cass_statement_bind_int32(stmt.get(), 4, static_cast<cass_int32_t>(num_chunks));
+            cass_statement_bind_int32(stmt.get(), 5, static_cast<cass_int32_t>(sc));
+            cass_batch_add_statement(batch.get(), stmt.get());
+            batch_bytes   += chunk.size();
+            batch_has_rows = true;
+        }
+        if (batch_has_rows) {
+            auto shared_batch = std::shared_ptr<CassBatch>(batch.release(), cass_batch_free);
+            tasks.push_back({
+                .submit = [session = session_, shared_batch] {
+                    return FuturePtr{cass_session_execute_batch(session, shared_batch.get())};
+                },
+            });
+        }
+    }
+    run_async_tasks(max_concurrency, tasks, "INSERT batch");
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore::read
+// ---------------------------------------------------------------------------
+
+/// Reads the blob back as an ordered vector<Bytes> (one element per chunk_id):
+///   1. Fetches the sentinel row (salt=0, chunk_id=0) for total_chunks and
+///      salt_cardinality.  Returns std::nullopt immediately if the key does
+///      not exist.
+///   2. Returns an empty vector immediately when total_chunks == 0 (empty blob).
+///   3. Issues one SELECT per salt partition.  When max_concurrency == 0 all
+///      futures are fired at once and awaited in submission order; when
+///      max_concurrency > 0 a sliding window (semaphore + callback) bounds
+///      the number of in-flight futures.
+///   4. Each result set is iterated and every chunk is placed directly into
+///      chunks[chunk_id] in the pre-allocated output vector.
+///   5. Verifies that every chunk was received: since the blob is non-empty,
+///      every stored chunk has at least one byte, so any empty slot means a
+///      missing chunk_id.
+///   6. Returns the vector of chunks without concatenation — the caller
+///      obtains a flat view via std::views::join if needed.
+std::optional<std::vector<Bytes>> SaltedBlobStore::read(std::span<const std::uint8_t> key,
+                                                        int max_concurrency) {
+    prepare_();
+
+    const auto meta = fetch_meta(session_, p_select_meta_, key, "SELECT meta");
+    if (!meta) return std::nullopt;
+
+    const cass_int32_t total_chunks     = meta->total_chunks;
+    const cass_int32_t salt_cardinality = meta->salt_cardinality;
+    if (total_chunks == 0)
+        return std::vector<Bytes>{};
+    const int salts = salt_cardinality;
+
+    std::vector<Bytes> chunks(static_cast<std::size_t>(total_chunks));
+
+    run_async_tasks(
+        max_concurrency,
+        partition_select_tasks(
+            session_, p_select_partition_, key, salts,
+            [&](int /*salt*/, const CassResult* res) {
+                IteratorPtr it{cass_iterator_from_result(res)};
+                while (cass_iterator_next(it.get())) {
+                    const CassRow*     row  = cass_iterator_get_row(it.get());
+                    const cass_int32_t cid  = get_int32(cass_row_get_column(row, 0));
+                    const cass_byte_t* data = nullptr;
+                    std::size_t        len  = 0uz;
+                    cass_value_get_bytes(cass_row_get_column(row, 1), &data, &len);
+                    if (cid < 0 || cid >= total_chunks)
+                        throw std::runtime_error("chunk_id out of range");
+                    if (len == 0uz)
+                        throw std::runtime_error(std::format("chunk_id {}: corrupt chunk row (empty payload)", cid));
+                    chunks[static_cast<std::size_t>(cid)].assign(data, data + len);
+                }
+            }),
+        "SELECT partition");
+
+    if (const auto miss = std::ranges::find_if(chunks, &Bytes::empty);
+        miss != chunks.end()) [[unlikely]]
+        throw std::runtime_error(std::format("missing chunk_id {} of {}",
+                                             std::distance(chunks.begin(), miss),
+                                             total_chunks));
+
+    return chunks;
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore::erase
+// ---------------------------------------------------------------------------
+
+/// Deletes all CQL partitions associated with @p key.
+///
+/// Reads the sentinel row to learn the salt cardinality, then issues one
+/// DELETE per partition.  Non-sentinel partitions (salt > 0) are removed
+/// first; salt=0 (the metadata row) is always deleted last so a failed erase
+/// can be retried.  If the key does not exist (no sentinel row), returns
+/// silently — idempotent by design.
+void SaltedBlobStore::erase(std::span<const std::uint8_t> key, int max_concurrency) {
+    prepare_();
+
+    const auto meta = fetch_meta(session_, p_select_meta_, key, "SELECT meta (erase)");
+    if (!meta) return;
+
+    const int salt_count = meta->salt_cardinality;
+
+    auto delete_tasks = [&](int first, int last) -> std::vector<AsyncTask> {
+        std::vector<AsyncTask> tasks;
+        tasks.reserve(static_cast<std::size_t>(last - first));
+        for (int s : std::views::iota(first, last)) {
+            tasks.push_back({
+                .submit = [session = session_, p_delete = p_delete_partition_, key, s] {
+                    StatementPtr stmt{cass_prepared_bind(p_delete)};
+                    bind_blob(stmt.get(), 0, key);
+                    cass_statement_bind_int32(stmt.get(), 1, s);
+                    return FuturePtr{cass_session_execute(session, stmt.get())};
+                },
+            });
+        }
+        return tasks;
+    };
+
+    run_async_tasks(max_concurrency, delete_tasks(1, salt_count), "DELETE partition");
+    run_async_tasks(max_concurrency, delete_tasks(0, 1), "DELETE partition");
+}
+
+// ---------------------------------------------------------------------------
+// SaltedBlobStore::describe
+// ---------------------------------------------------------------------------
+
+/// Queries each salt partition and accumulates row count and total chunk bytes
+/// into a PartitionInfo per salt.  When @p max_concurrency == 0 all SELECTs are
+/// fired at once; when @p max_concurrency > 0 a sliding window bounds in-flight
+/// futures (same pattern as read).
+std::optional<BlobLayout> SaltedBlobStore::describe(std::span<const std::uint8_t> key,
+                                                    int max_concurrency) {
+    prepare_();
+
+    const auto meta = fetch_meta(session_, p_select_meta_, key, "SELECT meta (describe)");
+    if (!meta) return std::nullopt;
+
+    BlobLayout layout{
+        .total_chunks     = meta->total_chunks,
+        .salt_cardinality = meta->salt_cardinality,
+    };
+    const int salts = layout.salt_cardinality;
+    layout.partitions.resize(static_cast<std::size_t>(salts));
+
+    run_async_tasks(
+        max_concurrency,
+        partition_select_tasks(
+            session_, p_select_partition_, key, salts,
+            [&](int salt, const CassResult* res) {
+                IteratorPtr it{cass_iterator_from_result(res)};
+                PartitionInfo info{.salt = salt};
+                while (cass_iterator_next(it.get())) {
+                    const CassRow*     row  = cass_iterator_get_row(it.get());
+                    const cass_byte_t* data = nullptr;
+                    std::size_t        len  = 0uz;
+                    cass_value_get_bytes(cass_row_get_column(row, 1), &data, &len);
+                    info.rows  += 1uz;
+                    info.bytes += len;
+                }
+                layout.partitions[static_cast<std::size_t>(salt)] = info;
+            }),
+        "SELECT partition (describe)");
+
+    return layout;
+}
+
+}  // namespace scs

--- a/chunking-large-cells/cpp/salted_blob_store.h
+++ b/chunking-large-cells/cpp/salted_blob_store.h
@@ -1,0 +1,265 @@
+/// @file salted_blob_store.h
+/// @brief Modified salting technique for storing large blobs in ScyllaDB.
+///
+/// Each blob is split into fixed-size chunks and distributed across multiple
+/// CQL partitions using a salt value.  Spreading data this way avoids hot
+/// partitions and keeps individual rows well within ScyllaDB's recommended
+/// cell-size limits.
+///
+/// Schema (created by SaltedBlobStore::create_schema):
+/// @code
+///   CREATE TABLE <ks>.<t> (
+///       key              blob,
+///       salt             int,
+///       chunk_id         int,
+///       chunk            blob,
+///       total_chunks     int,
+///       salt_cardinality int,
+///       PRIMARY KEY ((key, salt), chunk_id)
+///   );
+/// @endcode
+///
+/// The sentinel row (salt=0, chunk_id=0) carries @c total_chunks and
+/// @c salt_cardinality so readers can discover the full layout without
+/// scanning empty partitions.
+///
+/// Reference: blog post "Storing large blobs in ScyllaDB".
+
+#pragma once
+
+#include <cassandra.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace scs {
+
+/// @brief Default size of each chunk stored in a single CQL row (4 KiB).
+///
+/// Keeping chunks small limits the size of individual CQL cells, which
+/// ScyllaDB handles efficiently.  Larger values reduce row count but increase
+/// cell size; tune for your workload.
+inline constexpr std::size_t kDefaultChunkSize = 4096uz;
+
+/// @brief Default upper bound on the salt value (exclusive).
+///
+/// Actual salt cardinality is @c min(num_chunks, max_salt), so a blob with
+/// fewer chunks than this limit uses a smaller cardinality automatically.
+inline constexpr int kDefaultMaxSalt = 100;
+
+/// @brief Maximum payload per UNLOGGED batch before it is flushed (1 MiB).
+///
+/// ScyllaDB rejects batches that exceed @c batch_size_fail_threshold_in_kb
+/// (default 50 MiB).  This limit sits well below that threshold while still
+/// amortising round-trip overhead for large blobs.
+inline constexpr std::size_t kDefaultMaxBatchBytes = 1uz * 1024 * 1024;
+
+/// @brief Maximum number of CQL futures that may be in-flight simultaneously.
+///
+/// Limits the number of concurrent batch executions (write) and partition
+/// reads/deletes/describes (read, erase, describe).  A value of 0 means no limit — all futures
+/// are issued at once, preserving the previous behaviour.
+///
+/// Tune downward if you observe driver-queue or server-side pressure; tune
+/// upward (or leave at 0) when the number of salt partitions is bounded
+/// naturally by @p kDefaultMaxSalt.
+inline constexpr int kDefaultMaxConcurrency = 0;
+
+/// @brief Owned byte buffer — the return type of SaltedBlobStore::read.
+///
+using Bytes = std::vector<std::uint8_t>;
+
+/// @brief Per-partition storage statistics returned by SaltedBlobStore::describe.
+///
+struct PartitionInfo {
+    int         salt  = 0;  ///< Salt value that identifies this partition.
+    std::size_t rows  = 0;  ///< Number of chunk rows stored in this partition.
+    std::size_t bytes = 0;  ///< Total raw chunk bytes stored in this partition.
+};
+
+/// @brief Full layout description of a stored blob.
+///
+/// Returned by SaltedBlobStore::describe.  @c partitions contains one entry
+/// per salt value that was actually written; the sum of all @c bytes fields
+/// equals the original blob size (excluding any padding for empty blobs).
+struct BlobLayout {
+    int                        total_chunks     = 0;  ///< Total number of chunks the blob was split into.
+    int                        salt_cardinality = 0;  ///< Number of distinct salt partitions used.
+    std::vector<PartitionInfo> partitions;            ///< Per-partition breakdown; one element per salt.
+
+    /// @brief Sum of the raw chunk bytes across all partitions.
+    ///
+    /// @return Total stored byte count (may be 0 for an empty blob).
+    ///
+    std::size_t total_bytes() const noexcept;
+};
+
+/// @brief Read/write facade over the salted-blob schema.
+///
+/// @par Ownership
+/// Does @b not own the @c CassSession.  The caller is responsible for
+/// connecting and tearing it down; the session must outlive this object.
+///
+/// @par Thread safety
+/// Not thread-safe.  Each thread should use its own instance.
+///
+/// @par Input buffers
+/// All key and blob parameters are @c std::span<const uint8_t> so callers
+/// can pass any contiguous buffer — @c std::vector, raw array,
+/// @c string_view-derived pointer pair — without an extra copy.
+class SaltedBlobStore {
+public:
+    /// @brief Constructs the store targeting the given keyspace and table.
+    ///
+    /// The constructor does @b not touch ScyllaDB.  Call create_schema() to
+    /// create the keyspace/table and prepare the driver statements before
+    /// performing any reads or writes.
+    ///
+    /// @param session   Connected CassSession (non-owning).
+    /// @param keyspace  CQL keyspace name that contains (or will contain) the table.
+    /// @param table     CQL table name (defaults to @c "salted_blobs").
+    SaltedBlobStore(CassSession* session,
+                    std::string  keyspace,
+                    std::string  table = "salted_blobs");
+
+    /// @brief Releases all driver-prepared statements.
+    ///
+    /// Does @b not close or free the underlying @c CassSession.
+    ~SaltedBlobStore();
+
+    SaltedBlobStore(const SaltedBlobStore&)            = delete;
+    SaltedBlobStore& operator=(const SaltedBlobStore&) = delete;
+    SaltedBlobStore(SaltedBlobStore&&)                 noexcept = delete;
+    SaltedBlobStore& operator=(SaltedBlobStore&&)      noexcept = delete;
+
+    /// @brief Creates the keyspace and table if they do not already exist,
+    ///        then prepares the driver statements.
+    ///
+    /// Safe to call on an already-initialised cluster; the @c IF NOT EXISTS
+    /// guards make it idempotent.  Blocks until all DDL statements have
+    /// completed on the coordinator.
+    ///
+    /// @param replication_factor  SimpleStrategy replication factor (default 1).
+    /// @throws std::runtime_error if any CQL statement fails.
+    void create_schema(int replication_factor = 1);
+
+    /// @brief Drops the entire keyspace (and all its tables) unconditionally.
+    ///
+    /// Also releases the prepared statements cached in this instance so the
+    /// object can be reused against a freshly created schema.  Blocks until
+    /// the DROP KEYSPACE completes.
+    ///
+    /// @throws std::runtime_error if the CQL statement fails.
+    void drop_schema();
+
+    /// @brief Writes a blob into the store, splitting and salting as needed.
+    ///
+    /// The blob is divided into @p chunk_size byte chunks.  Chunks are
+    /// distributed round-robin across @c min(num_chunks, max_salt) salt
+    /// values, each salt forming its own CQL partition.  Chunks belonging to
+    /// the same partition are batched together up to @p max_batch_bytes before
+    /// being sent, keeping individual batch payloads within server limits.
+    ///
+    /// At most @p max_concurrency batch futures are kept in-flight at once.
+    /// A @c std::counting_semaphore is acquired before each submission; the
+    /// completion callback releases it, so whichever future finishes first
+    /// unblocks the producer immediately (true sliding window, no FIFO
+    /// stalling).  Pass 0 (or @c kDefaultMaxConcurrency) to issue all batches
+    /// at once without a cap.
+    ///
+    /// @note @p max_salt and @p chunk_size are per-call settings stored in
+    ///       each row, so different keys in the same table may use different
+    ///       layouts.
+    ///
+    /// @param key             Logical blob key; used as the CQL partition key component.
+    /// @param blob            Raw bytes to store.
+    /// @param max_salt        Maximum number of salt partitions to use.
+    /// @param chunk_size      Maximum bytes per CQL row.
+    /// @param max_batch_bytes Soft flush threshold for UNLOGGED batches (must be >= chunk_size).
+    /// @param max_concurrency Max in-flight batch futures (0 = unlimited).
+    /// @throws std::invalid_argument if any tuning parameter is out of range
+    ///         (@p max_salt, @p chunk_size, @p max_batch_bytes, @p max_concurrency).
+    /// @throws std::runtime_error    if any batch future returns a driver error.
+    void write(std::span<const std::uint8_t> key,
+               std::span<const std::uint8_t> blob,
+               int         max_salt        = kDefaultMaxSalt,
+               std::size_t chunk_size      = kDefaultChunkSize,
+               std::size_t max_batch_bytes = kDefaultMaxBatchBytes,
+               int         max_concurrency = kDefaultMaxConcurrency);
+
+    /// @brief Returns the chunks of the blob stored under @p key, in order.
+    ///
+    /// Reads the sentinel row first to discover @c total_chunks and
+    /// @c salt_cardinality, then issues one SELECT per salt partition.
+    /// With @p max_concurrency == 0 all SELECTs are fired at once and awaited
+    /// together; with @p max_concurrency > 0 a sliding window (semaphore +
+    /// callback) limits the number of in-flight futures.  Chunks are placed
+    /// directly into a pre-allocated @c vector<Bytes> indexed by @c chunk_id;
+    /// no flat concatenation is performed so the caller avoids an extra copy.
+    /// Use std::views::join to get a flat view if needed.
+    ///
+    /// @param key             Logical blob key to look up.
+    /// @param max_concurrency Max in-flight SELECT futures (0 = unlimited).
+    /// @return Ordered @c vector<Bytes> of chunks (one element per chunk_id),
+    ///         or @c std::nullopt if @p key is unknown.
+    /// @throws std::runtime_error if metadata is corrupt, a chunk is missing,
+    ///         or a driver call fails.
+    std::optional<std::vector<Bytes>> read(std::span<const std::uint8_t> key,
+                                           int max_concurrency = kDefaultMaxConcurrency);
+
+    /// @brief Deletes all rows associated with @p key.
+    ///
+    /// Reads the sentinel row to find the salt cardinality, then issues one
+    /// DELETE per partition.  Non-sentinel partitions (@c salt != 0) are
+    /// removed first; @c salt=0 (metadata) is deleted last so a failed erase
+    /// can be retried.  If @p key is not found, returns silently without error.
+    ///
+    /// @param key             Logical blob key to delete.
+    /// @param max_concurrency Max in-flight DELETE futures (0 = unlimited).
+    /// @throws std::runtime_error if a driver call fails.
+    void erase(std::span<const std::uint8_t> key,
+               int max_concurrency = kDefaultMaxConcurrency);
+
+    /// @brief Returns the storage layout of the blob stored under @p key.
+    ///
+    /// For each salt partition, reports the row count and total chunk bytes.
+    /// Useful for diagnostics and understanding the salting distribution.
+    /// With @p max_concurrency == 0 all partition SELECTs are fired at once;
+    /// with @p max_concurrency > 0 a sliding window limits in-flight futures
+    /// (same pattern as read).
+    ///
+    /// @param key             Logical blob key to inspect.
+    /// @param max_concurrency Max in-flight SELECT futures (0 = unlimited).
+    /// @return Layout description, or @c std::nullopt if @p key is unknown.
+    /// @throws std::runtime_error if a driver call fails.
+    std::optional<BlobLayout> describe(std::span<const std::uint8_t> key,
+                                       int max_concurrency = kDefaultMaxConcurrency);
+
+private:
+    /// @brief Prepares all four CQL statements if not already prepared (idempotent).
+    ///
+    void prepare_();
+
+    /// @brief Executes a single-parameter-free CQL statement synchronously.
+    ///
+    void execute_simple_(const std::string& cql);
+
+    /// @brief Frees and nulls all cached CassPrepared handles.
+    ///
+    void release_prepared_();
+
+    CassSession* session_;
+    std::string  keyspace_;
+    std::string  table_;
+
+    const CassPrepared* p_insert_           = nullptr;  ///< INSERT INTO … VALUES (?,?,?,?,?,?)
+    const CassPrepared* p_select_meta_      = nullptr;  ///< SELECT total_chunks, salt_cardinality … WHERE salt=0 AND chunk_id=0
+    const CassPrepared* p_select_partition_ = nullptr;  ///< SELECT chunk_id, chunk … WHERE key=? AND salt=?
+    const CassPrepared* p_delete_partition_ = nullptr;  ///< DELETE … WHERE key=? AND salt=?
+};
+
+}  // namespace scs

--- a/chunking-large-cells/python/.flake8
+++ b/chunking-large-cells/python/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/chunking-large-cells/python/README.md
+++ b/chunking-large-cells/python/README.md
@@ -1,0 +1,198 @@
+# Chunking large cells — Python demo
+
+A runnable companion to the blog post **"Storing large blobs in ScyllaDB"**.
+It implements the *Modified Salting* technique: large blobs are split into
+fixed-size chunks distributed across `salt_cardinality` partitions per key,
+so reads and writes can be parallelised across shards while the metadata
+(`total_chunks`, `salt_cardinality`) carried on `(salt=0, chunk_id=0)`
+prevents wasteful scans of empty partitions.
+
+## Files
+
+| File                   | Purpose                                                                 |
+|------------------------|-------------------------------------------------------------------------|
+| `salted_blob_store.py` | Library: schema management, write, read, delete, describe               |
+| `demo.py`              | End-to-end demo (small / medium / large blobs, round-trip verification) |
+| `benchmark.py`         | Large-blob vs small-blob throughput and latency benchmark               |
+| `requirements.txt`     | Python dependencies                                                     |
+
+## Schema
+
+```cql
+CREATE TABLE <keyspace>.salted_blobs (
+    key blob,
+    salt int,
+    chunk_id int,
+    chunk blob,
+    total_chunks int,
+    salt_cardinality int,
+    PRIMARY KEY ((key, salt), chunk_id)
+);
+```
+
+## Quick start
+
+```bash
+# 1. Bring up a single-node ScyllaDB
+docker run --name scylla-blobs -d -p 9042:9042 scylladb/scylla \
+    --smp 2 --memory 2G --overprovisioned 1
+
+# 2. Install the driver
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# 3. Run the demo
+python demo.py --contact-points 127.0.0.1
+```
+
+The demo will:
+
+1. create keyspace `salted_blob_demo` and table `salted_blobs`,
+2. write a 2 KiB blob with `max_salt=1` (no chunking),
+3. write a 256 KiB blob with `max_salt=8` (a handful of salts),
+4. write an 8 MiB blob with `max_salt=100`, `chunk_size=64 KiB`
+   (high parallelism — bump it with `--large-mb 30` to mirror the blog),
+5. round-trip every blob and verify the SHA-256 digest,
+6. dump how each blob is laid out across salted partitions,
+7. show that `read()` of a missing key returns `None`,
+8. delete a key and confirm it's gone.
+
+Pass `--cleanup` to drop the keyspace at the end.  
+Use `--max-concurrency N` to cap the number of in-flight CQL futures inside
+each `write()` / `read()` / `delete()` call (default `0` = unlimited).
+
+## Benchmark — large blobs vs small blobs
+
+`benchmark.py` measures the same total byte volume written and read two ways:
+
+| Case            | What is one "operation"                                                                       |
+|-----------------|-----------------------------------------------------------------------------------------------|
+| **Large blobs** | Write / read one `--large-mb` MiB blob via `SaltedBlobStore` (chunks parallelised internally) |
+| **Small blobs** | One CQL `INSERT` / `SELECT` of a single `--small-kb` KiB row                                  |
+
+The final report prints per-operation latency (min / p50 / p99 / max) and
+aggregate throughput (MiB/s) side-by-side for both cases.
+
+```bash
+# Quick smoke-test: 10 × 30 MiB large blobs ≈ 300 MiB total
+python benchmark.py --count 10
+
+# Full benchmark: 1,000 × 30 MiB ≈ 30 GiB total (requires sufficient disk)
+python benchmark.py --count 1000
+
+# Tune blob sizes and concurrency
+python benchmark.py --count 100 --large-mb 30 --small-kb 128 --concurrency 128
+
+# Cap in-flight store futures for large-blob ops (sliding window inside SaltedBlobStore)
+python benchmark.py --count 10 --store-concurrency 32
+
+# Drop the keyspace when done
+python benchmark.py --count 10 --cleanup
+```
+
+Key flags:
+
+| Flag                    | Default      | Description                                                               |
+|-------------------------|--------------|---------------------------------------------------------------------------|
+| `--contact-points`      | `127.0.0.1`  | Comma-separated ScyllaDB host list (or `SCYLLA_CONTACT_POINTS`)           |
+| `--port`                | `9042`       | CQL port (or `SCYLLA_PORT`)                                               |
+| `--username`            | _(none)_     | CQL username (or `SCYLLA_USERNAME`)                                       |
+| `--password`            | _(none)_     | CQL password (or `SCYLLA_PASSWORD`)                                       |
+| `--keyspace`            | `blob_bench` | Keyspace to use                                                           |
+| `--rf`                  | `1`          | Replication factor                                                        |
+| `--count N`             | `1000`       | Number of large blobs                                                     |
+| `--large-mb M`          | `30`         | Each large blob in MiB                                                    |
+| `--small-kb K`          | `64`         | Each small blob in KiB                                                    |
+| `--chunk-size-kb C`     | `64`         | Chunk size for salting                                                    |
+| `--max-salt S`          | `100`        | Parallel shard spread for large blobs                                     |
+| `--concurrency P`       | `64`         | Async window for small-blob ops (must be `>= 1`)                          |
+| `--store-concurrency N` | `0`          | Max in-flight futures inside `SaltedBlobStore.write/read` (0 = unlimited) |
+| `--skip-large`          | off          | Reuse already-written large blobs                                         |
+| `--skip-small`          | off          | Skip the small-blob case                                                  |
+| `--cleanup`             | off          | Drop keyspace on exit                                                     |
+
+> **Disk budget**: `count × large_mb` MiB plus the equivalent small-blob
+> volume. For the default `1000 × 30 MiB` run that is roughly **60 GiB**
+> (both tables together with RF=1). Use `--count 10` or `--count 100` for
+> smaller runs.
+
+## Library usage
+
+```python
+from cassandra.cluster import Cluster
+from salted_blob_store import SaltedBlobStore
+import itertools
+
+cluster = Cluster(["127.0.0.1"])
+session = cluster.connect()
+
+store = SaltedBlobStore(session, keyspace="my_ks")
+store.create_schema(replication={"class": "SimpleStrategy", "replication_factor": 1})
+
+# Hybrid policy: small blobs stay on a single partition,
+# big blobs spread across many shards.
+store.write(key=b"small", blob=b"...", max_salt=1, chunk_size=4096)
+store.write(key=b"huge",  blob=big_bytes, max_salt=100, chunk_size=64 * 1024)
+
+# max_concurrency > 0 enables a true sliding window: at most N batch / SELECT
+# futures are in-flight at once; 0 (default) fires all of them concurrently.
+store.write(key=b"huge2", blob=big_bytes, max_salt=100, chunk_size=64 * 1024,
+            max_concurrency=32)
+
+assert all(a == b for a, b in zip(itertools.chain.from_iterable(store.read(b"small")), b"...", strict=True))
+print(store.describe(b"huge"))
+```
+
+`max_salt` and `chunk_size` are per-call arguments — the same table can hold
+keys with completely different salting parameters, which is the central
+flexibility the blog highlights versus classic salting.
+
+## Notes
+
+* **`write()` parameter checks** — invalid tuning values raise `ValueError`
+  before any CQL is issued:
+
+  | Parameter         | Constraint                          |
+  |-------------------|-------------------------------------|
+  | `max_salt`        | `>= 1`                              |
+  | `chunk_size`      | `>= 1`                              |
+  | `max_batch_bytes` | `>= chunk_size` (and `>= 1`)        |
+  | `max_concurrency` | `>= 0` (`0` = unlimited in-flight)  |
+
+  The `max_batch_bytes >= chunk_size` rule guarantees every UNLOGGED batch
+  can hold at least one full chunk, so batch sizing stays predictable
+  relative to the server's `batch_size_fail_threshold_in_kb`.  Default
+  `max_batch_bytes` is 1 MiB (`DEFAULT_MAX_BATCH_BYTES`).
+* **Empty blobs** — `write(key, b"")` stores a single sentinel row
+  `(salt=0, chunk_id=0)` with `total_chunks=0`.  `read(key)` short-circuits
+  on that sentinel and returns `[]` without issuing any partition SELECTs.
+* Writes use `BatchType.UNLOGGED` per salted partition (one batch per salt,
+  split into smaller batches once the accumulated chunk payload exceeds
+  `max_batch_bytes` — default 1 MiB — so the server's
+  `batch_size_fail_threshold_in_kb` is not tripped).
+* Reads issue one async per-partition `SELECT` per salt and reassemble the
+  chunks in `chunk_id` order; the per-key metadata is fetched once via a
+  cheap point query against `(salt=0, chunk_id=0)`.
+* **Metadata validation** — `_fetch_meta()` raises `RuntimeError` if the
+  stored sentinel row has a negative `total_chunks` or non-positive
+  `salt_cardinality`, so `read`, `delete`, and `describe` all reject corrupt
+  metadata uniformly instead of silently proceeding with bad values.
+* **Chunk-row integrity** — `read()` rejects rows whose `chunk_id` is out of
+  range or whose payload is empty (an empty chunk row inside a non-empty
+  blob signals corruption, since `write()` only stores empty rows for empty
+  blobs via the `total_chunks=0` sentinel path).
+* **`delete()` ordering** — chunk partitions (`salt != 0`) are removed
+  first; the sentinel partition (`salt=0`, carrying `total_chunks` and
+  `salt_cardinality`) is deleted last.  If a delete fails partway through,
+  the sentinel row is still present so the operation can be retried.
+* **Concurrency control** — `write`, `read`, `delete`, and `describe` accept
+  `max_concurrency`:
+  * `0` (default) — all futures are issued at once; Python awaits them in
+    submission order (equivalent to the unlimited path in the C++ port).
+  * `N > 0` — a `threading.Semaphore(N)` limits in-flight futures to exactly
+    `N`; the driver's I/O thread releases a slot the moment any future
+    completes, immediately unblocking the producer for the next one (true
+    sliding window, no FIFO batch-stalling).  A drain loop acquires all `N`
+    permits before returning, then re-raises the first error if any occurred.
+* `cassandra-driver` works against ScyllaDB; if you prefer the Scylla fork
+  swap the dependency for `scylla-driver` — the API is identical.

--- a/chunking-large-cells/python/benchmark.py
+++ b/chunking-large-cells/python/benchmark.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""
+Large-blob vs small-blob benchmark for ScyllaDB.
+
+Compares the same total byte volume written and read in two ways:
+
+  LARGE BLOB CASE
+    --count blobs, each --large-mb MiB, stored via Modified-Salting
+    (SaltedBlobStore: chunked across multiple partitions, reads/writes
+    parallelised with async CQL).  One write() or read() call constitutes
+    a single "operation" whose wall-clock time is measured.
+
+  SMALL BLOB CASE
+    ceil(count * large_mb / small_kb) blobs, each --small-kb KiB, stored
+    as a single row per blob (one CQL INSERT or SELECT per operation).
+    A sliding async window of --concurrency outstanding requests drives
+    throughput.
+
+The final report shows per-operation latency (min / p50 / p99 / max) and
+aggregate throughput (MiB/s) side-by-side for both cases.
+
+Defaults: 1,000 × 30 MiB large blobs  ≈ 29.3 GiB total
+          matched by ~480,000 × 64 KiB small blobs
+WARNING : 1,000 × 30 MiB requires ~30 GiB of free disk space on ScyllaDB.
+          Use --count 10 (or --count 100) for a faster smoke-test.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import threading
+import time
+from typing import List, Optional, Tuple
+
+from cassandra.auth import PlainTextAuthProvider  # type: ignore[import-untyped]
+from cassandra.cluster import Cluster             # type: ignore[import-untyped]
+
+from salted_blob_store import DEFAULT_MAX_CONCURRENCY, SaltedBlobStore
+
+# ── formatting helpers ────────────────────────────────────────────────────────
+
+RULER = "━" * 72
+
+
+def fmt_bytes(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(n) < 1024:
+            return f"{n:.2f} {unit}"
+        n /= 1024
+    return f"{n:.2f} PiB"
+
+
+def fmt_ms(ms: float) -> str:
+    if ms < 1_000:
+        return f"{ms:.1f} ms"
+    return f"{ms / 1_000:.2f} s"
+
+
+def fmt_s(s: float) -> str:
+    if s < 60:
+        return f"{s:.1f} s"
+    m, sec = divmod(s, 60)
+    return f"{int(m)}m {sec:.0f}s"
+
+
+def pct(data: List[float], p: float) -> float:
+    """
+    Return the p-th percentile of data (linear interpolation).
+    """
+    if not data:
+        return 0.0
+    s = sorted(data)
+    idx = p / 100.0 * (len(s) - 1)
+    lo, hi = int(idx), min(int(idx) + 1, len(s) - 1)
+    return s[lo] + (s[hi] - s[lo]) * (idx - lo)
+
+
+def _progress(done: int, total: int, t_start: float) -> None:
+    elapsed = time.perf_counter() - t_start
+    frac = done / total if total else 0
+    eta = (elapsed / frac - elapsed) if frac > 0 else 0
+    width = 30
+    filled = int(width * frac)
+    bar = "█" * filled + "░" * (width - filled)
+    print(
+        f"\r  [{bar}] {done:>{len(str(total))}}/{total}"
+        f"  {elapsed:.0f}s elapsed  ~{eta:.0f}s left   ",
+        end="",
+        flush=True,
+    )
+
+
+# ── large blob benchmark ──────────────────────────────────────────────────────
+
+
+def bench_large(
+    store: SaltedBlobStore,
+    count: int,
+    blob_size: int,
+    max_salt: int,
+    chunk_size: int,
+    payload: bytes,
+    store_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> Tuple[List[float], List[float], float, float]:
+    """
+    Write then read *count* large blobs.
+    Returns (write_latencies_s, read_latencies_s, write_wall_s, read_wall_s).
+
+    ``store_concurrency`` is forwarded to ``SaltedBlobStore.write()`` and
+    ``read()`` as ``max_concurrency`` (0 = unlimited, >0 = sliding window).
+    """
+    keys = [f"bench-large-{i:07d}".encode() for i in range(count)]
+
+    print(f"\n{RULER}")
+    print(f"  LARGE BLOB WRITE  —  {count:,} × {fmt_bytes(blob_size)}")
+    print(RULER)
+    write_lats: List[float] = []
+    t_wall = time.perf_counter()
+    report_step = max(1, count // 50)
+    for i, key in enumerate(keys):
+        t0 = time.perf_counter()
+        store.write(key, payload, max_salt=max_salt, chunk_size=chunk_size,
+                    max_concurrency=store_concurrency)
+        write_lats.append(time.perf_counter() - t0)
+        if (i + 1) % report_step == 0 or i + 1 == count:
+            _progress(i + 1, count, t_wall)
+    total_write_s = time.perf_counter() - t_wall
+    print(f"\n  done in {fmt_s(total_write_s)}  "
+          f"({fmt_bytes(count * blob_size / total_write_s)}/s)")
+
+    print(f"\n{RULER}")
+    print(f"  LARGE BLOB READ   —  {count:,} × {fmt_bytes(blob_size)}")
+    print(RULER)
+    read_lats: List[float] = []
+    t_wall = time.perf_counter()
+    for i, key in enumerate(keys):
+        t0 = time.perf_counter()
+        data = store.read(key, max_concurrency=store_concurrency)
+        read_lats.append(time.perf_counter() - t0)
+        assert data is not None, f"missing blob for key {key!r}"
+        if (i + 1) % report_step == 0 or i + 1 == count:
+            _progress(i + 1, count, t_wall)
+    total_read_s = time.perf_counter() - t_wall
+    print(f"\n  done in {fmt_s(total_read_s)}  "
+          f"({fmt_bytes(count * blob_size / total_read_s)}/s)")
+
+    return write_lats, read_lats, total_write_s, total_read_s
+
+
+# ── small blob benchmark ──────────────────────────────────────────────────────
+
+
+def _setup_small_table(session, ks: str) -> None:
+    session.execute(
+        f"CREATE TABLE IF NOT EXISTS {ks}.small_blobs ("
+        f"  key blob PRIMARY KEY, data blob)"
+    )
+
+
+def _run_async_window(session, stmt, params_list: list, concurrency: int) -> List[float]:
+    """
+    Issue async CQL requests with a true sliding window of *concurrency*
+    in-flight requests: the moment any op completes a new one is issued,
+    keeping the pipeline always full.
+
+    Uses a threading.Semaphore for backpressure (acquire before issue,
+    release in the per-future callback) so the producer never waits for
+    an entire batch to drain.
+
+    Returns per-operation latencies (wall-clock from issue to result).
+    """
+    n = len(params_list)
+    lats: List[float] = [0.0] * n
+    errors: List[Optional[Exception]] = [None]  # first error, shared via list
+    lock = threading.Lock()
+
+    slots = threading.Semaphore(concurrency)
+    t_wall = time.perf_counter()
+    report_step = max(1, n // 50)
+    completed = [0]  # mutable counter read by progress reports
+
+    def on_done(idx: int, t0: float, result, exc) -> None:  # noqa: ANN001
+        lats[idx] = time.perf_counter() - t0
+        if exc is not None:
+            with lock:
+                if errors[0] is None:
+                    errors[0] = exc
+        with lock:
+            completed[0] += 1
+        slots.release()
+
+    last_reported = 0
+    for i, params in enumerate(params_list):
+        slots.acquire()
+        if errors[0] is not None:
+            slots.release()   # unused permit — restore invariant
+            break
+        t0 = time.perf_counter()
+        fut = session.execute_async(stmt, params)
+        fut.add_callbacks(
+            callback=lambda res, idx=i, t0=t0: on_done(idx, t0, res, None),
+            errback=lambda exc, idx=i, t0=t0: on_done(idx, t0, None, exc),
+        )
+        with lock:
+            done_now = completed[0]
+        if done_now >= last_reported + report_step:
+            _progress(done_now, n, t_wall)
+            last_reported = done_now
+
+    # Drain: wait for all outstanding ops to release their permits.
+    for _ in range(concurrency):
+        slots.acquire()
+
+    _progress(completed[0], n, t_wall)
+
+    if errors[0] is not None:
+        raise RuntimeError(f"async op failed: {errors[0]}") from errors[0]
+
+    return lats
+
+
+def bench_small(
+    session,
+    ks: str,
+    total_bytes: int,
+    small_size: int,
+    payload: bytes,
+    concurrency: int,
+) -> Tuple[List[float], List[float], float, float]:
+    """
+    Write then read small blobs totalling *total_bytes*.
+    Each operation is a single CQL INSERT or SELECT.
+    Returns (write_latencies_s, read_latencies_s, write_wall_s, read_wall_s).
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    n_ops = math.ceil(total_bytes / small_size)
+    keys = [f"bench-small-{i:010d}".encode() for i in range(n_ops)]
+
+    stmt_w = session.prepare(
+        f"INSERT INTO {ks}.small_blobs (key, data) VALUES (?, ?)"
+    )
+    stmt_r = session.prepare(
+        f"SELECT data FROM {ks}.small_blobs WHERE key = ?"
+    )
+
+    print(f"\n{RULER}")
+    print(
+        f"  SMALL BLOB WRITE  —  {n_ops:,} × {fmt_bytes(small_size)}"
+        f"  (concurrency={concurrency})"
+    )
+    print(RULER)
+    t_wall = time.perf_counter()
+    write_lats = _run_async_window(
+        session, stmt_w, [(k, payload) for k in keys], concurrency
+    )
+    total_write_s = time.perf_counter() - t_wall
+    print(f"\n  done in {fmt_s(total_write_s)}  "
+          f"({fmt_bytes(total_bytes / total_write_s)}/s)")
+
+    print(f"\n{RULER}")
+    print(
+        f"  SMALL BLOB READ   —  {n_ops:,} × {fmt_bytes(small_size)}"
+        f"  (concurrency={concurrency})"
+    )
+    print(RULER)
+    t_wall = time.perf_counter()
+    read_lats = _run_async_window(
+        session, stmt_r, [(k,) for k in keys], concurrency
+    )
+    total_read_s = time.perf_counter() - t_wall
+    print(f"\n  done in {fmt_s(total_read_s)}  "
+          f"({fmt_bytes(total_bytes / total_read_s)}/s)")
+
+    return write_lats, read_lats, total_write_s, total_read_s
+
+
+# ── summary report ────────────────────────────────────────────────────────────
+
+
+def report(
+    large_write: List[float],
+    large_read: List[float],
+    large_blob_size: int,
+    large_count: int,
+    large_write_wall_s: float,
+    large_read_wall_s: float,
+    small_write: List[float],
+    small_read: List[float],
+    small_blob_size: int,
+    small_write_wall_s: float,
+    small_read_wall_s: float,
+) -> None:
+    total_bytes = large_count * large_blob_size
+    small_count = len(small_write)
+
+    lw_ms = [x * 1_000 for x in large_write]
+    lr_ms = [x * 1_000 for x in large_read]
+    sw_ms = [x * 1_000 for x in small_write]
+    sr_ms = [x * 1_000 for x in small_read]
+
+    def throughput(wall_s: float, nbytes: int) -> str:
+        if wall_s <= 0:
+            return "—"
+        return f"{nbytes / wall_s / (1024 ** 2):.1f} MiB/s"
+
+    lw_tp = throughput(large_write_wall_s, total_bytes)
+    lr_tp = throughput(large_read_wall_s, total_bytes)
+    sw_tp = throughput(small_write_wall_s, total_bytes)
+    sr_tp = throughput(small_read_wall_s, total_bytes)
+
+    total_lw_s = large_write_wall_s
+    total_lr_s = large_read_wall_s
+    total_sw_s = small_write_wall_s
+    total_sr_s = small_read_wall_s
+
+    # Column widths
+    C = 16
+
+    def row(label: str, lw: str, lr: str, sw: str, sr: str) -> None:
+        print(
+            f"  {label:<32}"
+            f"  {lw:>{C}}"
+            f"  {lr:>{C}}"
+            f"  {sw:>{C}}"
+            f"  {sr:>{C}}"
+        )
+
+    def lat_row(label: str, p: Optional[float]) -> None:
+        if p is None:
+            lw = fmt_ms(min(lw_ms))
+            lr = fmt_ms(min(lr_ms))
+            sw = fmt_ms(min(sw_ms))
+            sr = fmt_ms(min(sr_ms))
+        else:
+            lw = fmt_ms(pct(lw_ms, p))
+            lr = fmt_ms(pct(lr_ms, p))
+            sw = fmt_ms(pct(sw_ms, p))
+            sr = fmt_ms(pct(sr_ms, p))
+        row(label, lw, lr, sw, sr)
+
+    print(f"\n{RULER}")
+    print("  BENCHMARK RESULTS")
+    print(RULER)
+    print(
+        f"  Total payload   : {fmt_bytes(total_bytes)}"
+        f"  ({large_count:,} × {fmt_bytes(large_blob_size)} large"
+        f"  |  {small_count:,} × {fmt_bytes(small_blob_size)} small)"
+    )
+    print()
+    print(
+        f"  {'':32}"
+        f"  {'── LARGE BLOB ──':>{C}}"
+        f"  {'':>{C}}"
+        f"  {'── SMALL BLOB ──':>{C}}"
+        f"  {'':>{C}}"
+    )
+    row("", "WRITE", "READ", "WRITE", "READ")
+    print(f"  {'─'*32}  {'─'*C}  {'─'*C}  {'─'*C}  {'─'*C}")
+    row("Throughput", lw_tp, lr_tp, sw_tp, sr_tp)
+    print()
+    row("Total time", fmt_s(total_lw_s), fmt_s(total_lr_s),
+        fmt_s(total_sw_s), fmt_s(total_sr_s))
+    row("Op count",
+        f"{large_count:,}", f"{large_count:,}",
+        f"{small_count:,}", f"{small_count:,}")
+    print()
+    print(
+        f"  Per-op latency"
+        f"  [large = one {fmt_bytes(large_blob_size)} blob;"
+        f" small = one {fmt_bytes(small_blob_size)} CQL op]"
+    )
+    print(f"  {'─'*32}  {'─'*C}  {'─'*C}  {'─'*C}  {'─'*C}")
+    lat_row("  min", None)
+    lat_row("  p50", 50)
+    lat_row("  p99", 99)
+    row("  max",
+        fmt_ms(max(lw_ms)), fmt_ms(max(lr_ms)),
+        fmt_ms(max(sw_ms)), fmt_ms(max(sr_ms)))
+    print(RULER)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--contact-points",
+        default=os.environ.get("SCYLLA_CONTACT_POINTS", "127.0.0.1"),
+        help="Comma-separated ScyllaDB host list (default: 127.0.0.1).",
+    )
+    p.add_argument("--port", type=int, default=int(os.environ.get("SCYLLA_PORT", "9042")))
+    p.add_argument("--username", default=os.environ.get("SCYLLA_USERNAME"))
+    p.add_argument("--password", default=os.environ.get("SCYLLA_PASSWORD"))
+    p.add_argument("--keyspace", default="blob_bench")
+    p.add_argument("--rf", type=int, default=1, help="Replication factor (default: 1).")
+    p.add_argument(
+        "--count", type=int, default=1000,
+        help="Number of large blobs to write/read (default: 1000).",
+    )
+    p.add_argument(
+        "--large-mb", type=int, default=30,
+        help="Size of each large blob in MiB (default: 30).",
+    )
+    p.add_argument(
+        "--small-kb", type=int, default=64,
+        help="Size of each small blob in KiB (default: 64).",
+    )
+    p.add_argument(
+        "--chunk-size-kb", type=int, default=64,
+        help="Chunk size for large-blob salting in KiB (default: 64).",
+    )
+    p.add_argument(
+        "--max-salt", type=int, default=100,
+        help="max_salt (parallelism) for large blobs (default: 100).",
+    )
+    p.add_argument(
+        "--concurrency", type=int, default=64,
+        help="Async window size for small-blob ops (default: 64).",
+    )
+    p.add_argument(
+        "--store-concurrency", type=int, default=DEFAULT_MAX_CONCURRENCY,
+        help="Max in-flight CQL futures inside SaltedBlobStore.write/read "
+             "(0 = unlimited, default: 0).",
+    )
+    p.add_argument(
+        "--skip-large", action="store_true",
+        help="Skip the large-blob benchmark (use previously written data).",
+    )
+    p.add_argument(
+        "--skip-small", action="store_true",
+        help="Skip the small-blob benchmark.",
+    )
+    p.add_argument(
+        "--cleanup", action="store_true",
+        help="DROP the keyspace when the benchmark finishes.",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    blob_size   = args.large_mb * 1024 * 1024          # noqa: E221
+    small_size  = args.small_kb * 1024                 # noqa: E221
+    total_bytes = args.count * blob_size               # noqa: E221
+    n_small     = math.ceil(total_bytes / small_size)  # noqa: E221
+
+    print(RULER)
+    print("  ScyllaDB  ·  Large-vs-Small Blob Benchmark")
+    print(RULER)
+    print(f"  Large blobs  : {args.count:,} × {args.large_mb} MiB"
+          f"  =  {fmt_bytes(total_bytes)} total")
+    print(f"  Small blobs  : {n_small:,} × {args.small_kb} KiB"
+          f"  ≈  {fmt_bytes(n_small * small_size)} total")
+    print(f"  Chunk size   : {args.chunk_size_kb} KiB"
+          f"   max_salt={args.max_salt}"
+          f"   concurrency={args.concurrency}"
+          f"   store_concurrency={args.store_concurrency}")
+    print(f"  ScyllaDB     : {args.contact_points}:{args.port}"
+          f"   keyspace={args.keyspace}   rf={args.rf}")
+    print(RULER)
+
+    auth: Optional[PlainTextAuthProvider] = None
+    if args.username:
+        auth = PlainTextAuthProvider(
+            username=args.username, password=args.password or ""
+        )
+
+    cluster = Cluster(
+        contact_points=[h.strip() for h in args.contact_points.split(",") if h.strip()],
+        port=args.port,
+        auth_provider=auth,
+        protocol_version=4,
+    )
+    session = cluster.connect()
+
+    ks = args.keyspace
+    session.execute(
+        f"CREATE KEYSPACE IF NOT EXISTS {ks} WITH replication = "
+        f"{{'class': 'SimpleStrategy', 'replication_factor': {args.rf}}}"
+    )
+
+    # One fixed payload reused for all writes; content is irrelevant for
+    # an I/O benchmark and avoids generating gigabytes of random data.
+    print("\n  Generating payload buffers...", end=" ", flush=True)
+    large_payload = os.urandom(blob_size)
+    small_payload = large_payload[:small_size]
+    print("done.")
+
+    large_write_lats: List[float] = []
+    large_read_lats:  List[float] = []
+    large_write_wall_s: float = 0.0
+    large_read_wall_s:  float = 0.0
+    small_write_lats: List[float] = []
+    small_read_lats:  List[float] = []
+    small_write_wall_s: float = 0.0
+    small_read_wall_s:  float = 0.0
+
+    if not args.skip_large:
+        store = SaltedBlobStore(session, keyspace=ks, table="salted_blobs")
+        store.create_schema(
+            replication={"class": "SimpleStrategy", "replication_factor": args.rf}
+        )
+        large_write_lats, large_read_lats, large_write_wall_s, large_read_wall_s = bench_large(
+            store,
+            count=args.count,
+            blob_size=blob_size,
+            max_salt=args.max_salt,
+            chunk_size=args.chunk_size_kb * 1024,
+            payload=large_payload,
+            store_concurrency=args.store_concurrency,
+        )
+
+    if not args.skip_small:
+        _setup_small_table(session, ks)
+        small_write_lats, small_read_lats, small_write_wall_s, small_read_wall_s = bench_small(
+            session,
+            ks=ks,
+            total_bytes=total_bytes,
+            small_size=small_size,
+            payload=small_payload,
+            concurrency=args.concurrency,
+        )
+
+    if large_write_lats and small_write_lats:
+        report(
+            large_write_lats, large_read_lats, blob_size, args.count,
+            large_write_wall_s, large_read_wall_s,
+            small_write_lats, small_read_lats, small_size,
+            small_write_wall_s, small_read_wall_s,
+        )
+    else:
+        print("\n(Skipped one or both benchmark cases — no comparison printed.)")
+
+    if args.cleanup:
+        print(f"\n  Dropping keyspace {ks} ...", end=" ", flush=True)
+        session.execute(f"DROP KEYSPACE IF EXISTS {ks}")
+        print("done.")
+
+    cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/chunking-large-cells/python/demo.py
+++ b/chunking-large-cells/python/demo.py
@@ -1,0 +1,183 @@
+"""
+End-to-end demo of the modified salting technique against ScyllaDB.
+
+The demo exercises three blob sizes following the hybrid policy proposed in
+the blog post:
+
+* a small blob written without chunking (``max_salt=1``)
+* a medium blob spread across a handful of salts
+* a large blob spread across many salts to maximise shard parallelism
+
+For every case we round-trip the bytes through Scylla, verify the SHA-256
+digest, and dump how the blob was laid out across salted partitions.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import time
+from typing import Optional
+
+from cassandra.auth import PlainTextAuthProvider  # type: ignore[import-untyped]
+from cassandra.cluster import Cluster             # type: ignore[import-untyped]
+
+from salted_blob_store import DEFAULT_MAX_CONCURRENCY, SaltedBlobStore
+
+
+def fmt_bytes(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n:7.2f} {unit}"
+        n /= 1024
+    return f"{n:7.2f} TiB"
+
+
+def run_case(
+    store: SaltedBlobStore,
+    name: str,
+    key: bytes,
+    blob: bytes,
+    *,
+    max_salt: int,
+    chunk_size: int,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+) -> None:
+    digest_in = hashlib.sha256(blob).hexdigest()
+    print(f"\n=== {name} ===")
+    print(f"  key        : {key!r}")
+    print(f"  size       : {fmt_bytes(len(blob))}")
+    print(f"  max_salt   : {max_salt}")
+    print(f"  chunk_size : {fmt_bytes(chunk_size)}")
+    print(f"  sha256(in) : {digest_in}")
+
+    t0 = time.perf_counter()
+    store.write(key, blob, max_salt=max_salt, chunk_size=chunk_size,
+                max_concurrency=max_concurrency)
+    write_ms = (time.perf_counter() - t0) * 1000
+
+    t0 = time.perf_counter()
+    out = store.read(key, max_concurrency=max_concurrency)
+    read_ms = (time.perf_counter() - t0) * 1000
+
+    assert out is not None, "blob unexpectedly missing after write"
+    h = hashlib.sha256()
+    for chunk in out:
+        h.update(chunk)
+    digest_out = h.hexdigest()
+    print(f"  sha256(out): {digest_out}")
+    print(f"  write      : {write_ms:8.1f} ms")
+    print(f"  read       : {read_ms:8.1f} ms")
+    if digest_in != digest_out:
+        raise SystemExit("FAIL: round-trip digest mismatch")
+    print("  round-trip : OK")
+
+    layout = store.describe(key, max_concurrency=max_concurrency)
+    assert layout is not None
+    print(
+        f"  layout     : total_chunks={layout.total_chunks}, "
+        f"salt_cardinality={layout.salt_cardinality}, "
+        f"stored_bytes={fmt_bytes(layout.total_bytes)}"
+    )
+    preview = layout.partitions[:5]
+    for p in preview:
+        print(f"    salt={p.salt:>3}  rows={p.rows:>4}  bytes={fmt_bytes(p.bytes)}")
+    if len(layout.partitions) > len(preview):
+        print(f"    ... ({len(layout.partitions) - len(preview)} more salted partitions)")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--contact-points", default=os.environ.get("SCYLLA_CONTACT_POINTS", "127.0.0.1"),
+        help="Comma-separated host list (default: 127.0.0.1).",
+    )
+    p.add_argument("--port", type=int, default=int(os.environ.get("SCYLLA_PORT", "9042")))
+    p.add_argument("--username", default=os.environ.get("SCYLLA_USERNAME"))
+    p.add_argument("--password", default=os.environ.get("SCYLLA_PASSWORD"))
+    p.add_argument("--keyspace", default="salted_blob_demo")
+    p.add_argument("--table", default="salted_blobs")
+    p.add_argument("--rf", type=int, default=1, help="replication_factor for the demo keyspace")
+    p.add_argument(
+        "--large-mb", type=int, default=8,
+        help="Size of the large-blob test case in MiB (default: 8).",
+    )
+    p.add_argument(
+        "--max-concurrency", type=int, default=DEFAULT_MAX_CONCURRENCY,
+        help="Max in-flight CQL futures per store call (0 = unlimited, default: 0).",
+    )
+    p.add_argument("--cleanup", action="store_true", help="Drop the keyspace after the demo.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    auth: Optional[PlainTextAuthProvider] = None
+    if args.username:
+        auth = PlainTextAuthProvider(username=args.username, password=args.password or "")
+
+    cluster = Cluster(
+        contact_points=[h.strip() for h in args.contact_points.split(",") if h.strip()],
+        port=args.port,
+        auth_provider=auth,
+        protocol_version=4,
+    )
+    session = cluster.connect()
+    try:
+        store = SaltedBlobStore(session, keyspace=args.keyspace, table=args.table)
+        store.create_schema(replication={"class": "SimpleStrategy", "replication_factor": args.rf})
+
+        # Deterministic but non-trivial payloads.
+        rng = lambda seed, size: hashlib.shake_128(seed).digest(size)  # noqa: E731
+
+        # 1) Small blob: no chunking, single partition, single row.
+        run_case(
+            store, "small blob (no chunking)",
+            key=b"small-key",
+            blob=rng(b"small", 2 * 1024),  # 2 KiB
+            max_salt=1,
+            chunk_size=4096,
+            max_concurrency=args.max_concurrency,
+        )
+
+        # 2) Medium blob: a handful of salts, several rows per partition.
+        run_case(
+            store, "medium blob (a few salts)",
+            key=b"medium-key",
+            blob=rng(b"medium", 256 * 1024),  # 256 KiB
+            max_salt=8,
+            chunk_size=4096,
+            max_concurrency=args.max_concurrency,
+        )
+
+        # 3) Large blob: many salts, parallelism across shards.
+        large_size = args.large_mb * 1024 * 1024
+        run_case(
+            store, f"large blob (high salting, {args.large_mb} MiB)",
+            key=b"large-key",
+            blob=rng(b"large", large_size),
+            max_salt=100,
+            chunk_size=64 * 1024,  # 64 KiB chunks
+            max_concurrency=args.max_concurrency,
+        )
+
+        # Demonstrate read of a missing key.
+        print("\n=== missing key ===")
+        missing = store.read(b"does-not-exist", max_concurrency=args.max_concurrency)
+        print(f"  read(missing) -> {missing!r}")
+
+        # Demonstrate delete.
+        print("\n=== delete medium-key ===")
+        store.delete(b"medium-key", max_concurrency=args.max_concurrency)
+        print(f"  read(medium-key) -> {store.read(b'medium-key', max_concurrency=args.max_concurrency)!r}")
+
+        if args.cleanup:
+            print("\nCleaning up keyspace...")
+            store.drop_schema()
+    finally:
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/chunking-large-cells/python/requirements.txt
+++ b/chunking-large-cells/python/requirements.txt
@@ -1,0 +1,1 @@
+cassandra-driver>=3.29.0

--- a/chunking-large-cells/python/salted_blob_store.py
+++ b/chunking-large-cells/python/salted_blob_store.py
@@ -1,0 +1,547 @@
+"""
+Modified salting technique for storing large blobs in ScyllaDB.
+
+Each blob is split into fixed-size chunks. Chunks are distributed across
+``salt_cardinality`` partitions per key by ``chunk_id % salt_cardinality``.
+The sentinel row (``salt=0, chunk_id=0``) carries ``total_chunks`` and
+``salt_cardinality`` so a reader can rebuild the blob without scanning
+empty partitions.
+
+Schema::
+
+    CREATE TABLE <ks>.<t> (
+        key blob,
+        salt int,
+        chunk_id int,
+        chunk blob,
+        total_chunks int,
+        salt_cardinality int,
+        PRIMARY KEY ((key, salt), chunk_id)
+    );
+
+``SaltedBlobStore.write`` accepts per-call tuning parameters (``max_salt``,
+``chunk_size``, ``max_batch_bytes``, ``max_concurrency``) so different keys in
+the same table may use different layouts.  Before issuing CQL, ``write``
+validates:
+
+* ``max_salt >= 1``
+* ``chunk_size >= 1``
+* ``max_batch_bytes >= chunk_size``
+* ``max_concurrency >= 0`` (``0`` = unlimited in-flight futures)
+
+The ``max_batch_bytes >= chunk_size`` rule ensures each UNLOGGED batch can
+hold at least one full chunk.  Inserts within a salt partition are batched up
+to ``max_batch_bytes`` (default 1 MiB, ``DEFAULT_MAX_BATCH_BYTES``) so the
+server's ``batch_size_fail_threshold_in_kb`` is not tripped.
+
+Reference: blog post "Storing large blobs in ScyllaDB".
+"""
+from __future__ import annotations
+
+import functools
+import threading
+from dataclasses import dataclass
+from typing import Callable, Iterable, Iterator, List, Optional, Tuple
+
+from cassandra.cluster import ResponseFuture, ResultSet, Session          # type: ignore[import-untyped]
+from cassandra.query import BatchStatement, BatchType, PreparedStatement  # type: ignore[import-untyped]
+
+
+DEFAULT_CHUNK_SIZE = 4096
+DEFAULT_MAX_SALT = 100
+# UNLOGGED batches are bounded server-side (batch_size_fail_threshold_in_kb).
+# Keep the per-batch payload comfortably below that limit.
+DEFAULT_MAX_BATCH_BYTES = 1 * 1024 * 1024  # 1 MiB
+# 0 = unlimited (fire all futures at once); >0 = true sliding-window cap.
+DEFAULT_MAX_CONCURRENCY = 0
+
+
+@dataclass
+class _AsyncTask:
+    """
+    Submitter for a driver future plus an optional callback for its result.
+
+    ``submit()`` is invoked once and must return the ``ResponseFuture``
+    produced by ``Session.execute_async`` (single statement, batch, etc.).
+    ``handle`` — when supplied — is called exactly once with the
+    ``ResultSet`` returned by that future; write/delete tasks leave it
+    unset because they only care about success/failure.
+    """
+
+    submit: Callable[[], ResponseFuture]
+    handle: Optional[Callable[[ResultSet], None]] = None
+
+
+@dataclass
+class _Statements:
+    insert: PreparedStatement
+    select_meta: PreparedStatement
+    select_partition: PreparedStatement
+    delete_partition: PreparedStatement
+
+
+@dataclass
+class PartitionInfo:
+    salt: int
+    rows: int
+    bytes: int
+
+
+@dataclass
+class BlobLayout:
+    total_chunks: int
+    salt_cardinality: int
+    partitions: List[PartitionInfo]
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(p.bytes for p in self.partitions)
+
+
+class SaltedBlobStore:
+    """
+    Read/write API on top of the salted-blob schema.
+    """
+
+    def __init__(self, session: Session, keyspace: str, table: str = "salted_blobs"):
+        self.session = session
+        self.keyspace = keyspace
+        self.table = table
+        self._stmts: Optional[_Statements] = None
+
+    # ------------------------------------------------------------------ schema
+    def create_schema(self, replication: Optional[dict] = None) -> None:
+        replication = replication or {
+            "class": "NetworkTopologyStrategy",
+            "replication_factor": 1,
+        }
+        rep_str = ", ".join(
+            f"'{k}': '{v}'" if isinstance(v, str) else f"'{k}': {v}"
+            for k, v in replication.items()
+        )
+        self.session.execute(
+            f"CREATE KEYSPACE IF NOT EXISTS {self.keyspace} "
+            f"WITH replication = {{{rep_str}}}"
+        )
+        self.session.execute(
+            f"CREATE TABLE IF NOT EXISTS {self.keyspace}.{self.table} ("
+            f"  key blob,"
+            f"  salt int,"
+            f"  chunk_id int,"
+            f"  chunk blob,"
+            f"  total_chunks int,"
+            f"  salt_cardinality int,"
+            f"  PRIMARY KEY ((key, salt), chunk_id)"
+            f")"
+        )
+        self._prepare()
+
+    def drop_schema(self) -> None:
+        self.session.execute(f"DROP KEYSPACE IF EXISTS {self.keyspace}")
+        self._stmts = None
+
+    def _prepare(self) -> None:
+        if self._stmts is not None:
+            return
+        ks, t = self.keyspace, self.table
+        self._stmts = _Statements(
+            insert=self.session.prepare(
+                f"INSERT INTO {ks}.{t} "
+                f"(key, salt, chunk_id, chunk, total_chunks, salt_cardinality) "
+                f"VALUES (?, ?, ?, ?, ?, ?)"
+            ),
+            select_meta=self.session.prepare(
+                f"SELECT total_chunks, salt_cardinality FROM {ks}.{t} "
+                f"WHERE key = ? AND salt = 0 AND chunk_id = 0"
+            ),
+            select_partition=self.session.prepare(
+                f"SELECT chunk_id, chunk FROM {ks}.{t} WHERE key = ? AND salt = ?"
+            ),
+            delete_partition=self.session.prepare(
+                f"DELETE FROM {ks}.{t} WHERE key = ? AND salt = ?"
+            ),
+        )
+
+    def _fetch_meta(self, key: bytes) -> Optional[Tuple[int, int]]:
+        """
+        Return ``(total_chunks, salt_cardinality)`` from the sentinel row.
+
+        Returns ``None`` if the sentinel row is missing.  Raises
+        ``RuntimeError`` if the stored metadata is invalid (negative
+        ``total_chunks`` or non-positive ``salt_cardinality``); centralising
+        the check here means ``read``, ``delete``, and ``describe`` all
+        reject corrupt metadata uniformly.
+        """
+        self._prepare()
+        assert self._stmts is not None
+        meta = self.session.execute(self._stmts.select_meta, (key,)).one()
+        if meta is None:
+            return None
+        total_chunks, salt_cardinality = meta.total_chunks, meta.salt_cardinality
+        if total_chunks < 0 or salt_cardinality <= 0:
+            raise RuntimeError(
+                f"invalid metadata: total_chunks={total_chunks}, "
+                f"salt_cardinality={salt_cardinality}"
+            )
+        return total_chunks, salt_cardinality
+
+    def _scan_partitions(
+        self,
+        key: bytes,
+        salts: range,
+        max_concurrency: int,
+        on_rows: Callable[[int, ResultSet], None],
+        *,
+        op: str = "SELECT partition",
+    ) -> None:
+        """
+        Run ``select_partition`` for each salt and invoke ``on_rows(salt, rows)``.
+        """
+        assert self._stmts is not None
+        select = self._stmts.select_partition
+        self._run_async_tasks(
+            (
+                _AsyncTask(
+                    submit=functools.partial(
+                        self.session.execute_async, select, (key, s)
+                    ),
+                    handle=functools.partial(on_rows, s),
+                )
+                for s in salts
+            ),
+            max_concurrency,
+            op=op,
+        )
+
+    def _run_async_tasks(
+        self,
+        tasks: Iterable[_AsyncTask],
+        max_concurrency: int,
+        *,
+        op: str,
+    ) -> None:
+        """
+        Execute async tasks; optionally dispatch each future's result to ``handle``.
+        """
+        task_list = list(tasks)
+        if not task_list:
+            return
+
+        if max_concurrency <= 0:
+            futures = [(task, task.submit()) for task in task_list]
+            for task, fut in futures:
+                result = fut.result()
+                if task.handle is not None:
+                    task.handle(result)
+            return
+
+        slots = threading.Semaphore(max_concurrency)
+        first_err: List[Exception] = []
+        lock = threading.Lock()
+
+        def _record_err(exc: BaseException) -> None:
+            # Stash the first error; subsequent ones are dropped (the producer
+            # only raises one) but the lock keeps the assignment race-free.
+            with lock:
+                if not first_err:
+                    first_err.append(exc if isinstance(exc, Exception)
+                                     else Exception(repr(exc)))
+
+        def _on_done(result: ResultSet,
+                     *,
+                     handle: Optional[Callable[[ResultSet], None]]) -> None:
+            # try/finally: slots.release() MUST run even if handle() raises;
+            # otherwise the producer's drain loop would deadlock.  A raised
+            # handler exception is captured so it propagates to the caller
+            # instead of being swallowed by cassandra-driver's callback log.
+            try:
+                if handle is not None:
+                    handle(result)
+            except BaseException as exc:
+                _record_err(exc)
+            finally:
+                slots.release()
+
+        def _on_err(exc: Exception) -> None:
+            # Same try/finally guarantee: even if _record_err itself raises
+            # (e.g. allocation failure under memory pressure), the slot is
+            # still released and the drain loop can complete.
+            try:
+                _record_err(exc)
+            finally:
+                slots.release()
+
+        for task in task_list:
+            slots.acquire()
+            if first_err:
+                slots.release()
+                break
+            task.submit().add_callbacks(
+                callback=lambda result, h=task.handle: _on_done(result, handle=h),
+                errback=_on_err,
+            )
+
+        for _ in range(max_concurrency):
+            slots.acquire()
+        if first_err:
+            raise RuntimeError(f"{op}: {first_err[0]}")
+
+    # ------------------------------------------------------------------- write
+    def write(
+        self,
+        key: bytes,
+        blob: bytes,
+        max_salt: int = DEFAULT_MAX_SALT,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        max_batch_bytes: int = DEFAULT_MAX_BATCH_BYTES,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    ) -> None:
+        """
+        Store ``blob`` under ``key``.
+
+        ``max_salt`` and ``chunk_size`` may be chosen per-key without
+        affecting any other key in the table.
+
+        When ``max_concurrency > 0`` a true sliding window keeps exactly that
+        many batch futures in-flight at once; 0 (default) fires all batches
+        concurrently without a cap.
+
+        Raises:
+            ValueError: if any tuning parameter is out of range (see module
+                docstring).
+            RuntimeError: if a batch future fails.
+        """
+        if max_salt < 1:
+            raise ValueError("max_salt must be >= 1")
+        if chunk_size < 1:
+            raise ValueError("chunk_size must be >= 1")
+        if max_batch_bytes < 1:
+            raise ValueError("max_batch_bytes must be >= 1")
+        if max_concurrency < 0:
+            raise ValueError("max_concurrency must be >= 0")
+        if max_batch_bytes < chunk_size:
+            raise ValueError("max_batch_bytes must be >= chunk_size")
+        self._prepare()
+
+        if not blob:
+            # Empty blob: write a single sentinel row with total_chunks=0 so
+            # read() can return [] without issuing any partition SELECTs.
+            assert self._stmts is not None
+            self.session.execute(
+                self._stmts.insert,
+                (key, 0, 0, b"", 0, 1),
+            )
+            return
+
+        chunks = _split(blob, chunk_size)
+        num_chunks = len(chunks)
+        salt_cardinality = min(num_chunks, max_salt)
+
+        groups: List[List[int]] = [[] for _ in range(salt_cardinality)]
+        for chunk_id in range(num_chunks):
+            groups[chunk_id % salt_cardinality].append(chunk_id)
+
+        def _batch_tasks() -> Iterator[_AsyncTask]:
+            for salt, chunk_ids in enumerate(groups):
+                for batch in self._build_batches(
+                    key, salt, chunk_ids, chunks,
+                    num_chunks, salt_cardinality, max_batch_bytes,
+                ):
+                    yield _AsyncTask(
+                        submit=functools.partial(self.session.execute_async, batch)
+                    )
+
+        self._run_async_tasks(_batch_tasks(), max_concurrency, op="INSERT batch")
+
+    def _build_batches(
+        self,
+        key: bytes,
+        salt: int,
+        chunk_ids: List[int],
+        chunks: List[bytes],
+        total_chunks: int,
+        salt_cardinality: int,
+        max_batch_bytes: int,
+    ) -> Iterator[BatchStatement]:
+        assert self._stmts is not None
+        stmt = self._stmts.insert
+        batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+        batch_bytes = 0
+        for cid in chunk_ids:
+            data = chunks[cid]
+            if batch_bytes and batch_bytes + len(data) > max_batch_bytes:
+                yield batch
+                batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+                batch_bytes = 0
+            batch.add(stmt, (key, salt, cid, data, total_chunks, salt_cardinality))
+            batch_bytes += len(data)
+        if len(batch) > 0:
+            yield batch
+
+    # -------------------------------------------------------------------- read
+    def read(
+        self,
+        key: bytes,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    ) -> Optional[List[bytes]]:
+        """
+        Return the chunks of the blob stored under ``key`` (or ``None``).
+
+        Returns the raw list of chunks in order rather than assembling them
+        into a single buffer — mirrors the C++ ``vector<Bytes>`` return that
+        avoids the final concatenation copy. Use itertools.chain.from_iterable
+        to create a flat view of the chunks.
+
+        Returns an empty list immediately when the stored blob was empty
+        (``total_chunks == 0``).
+
+        When ``max_concurrency > 0`` a true sliding window keeps exactly that
+        many partition SELECT futures in-flight at once; 0 (default) fires all
+        partition SELECTs concurrently without a cap.
+
+        Raises:
+            RuntimeError: if the stored metadata is invalid, a chunk row has
+                an out-of-range ``chunk_id`` or an empty payload, or a chunk
+                is missing.
+        """
+        meta = self._fetch_meta(key)
+        if meta is None:
+            return None
+        total_chunks, salt_cardinality = meta
+
+        if total_chunks == 0:
+            return []
+
+        # Empty bytes b"" is the "not yet filled" sentinel.  Since
+        # write() handles empty blobs via the total_chunks=0 path above,
+        # every chunk of a non-empty blob is guaranteed non-empty — the
+        # _collect callback enforces this invariant on every incoming row.
+        chunks: List[bytes] = [b""] * total_chunks
+
+        def _collect(_salt: int, rows: ResultSet) -> None:
+            for row in rows:
+                cid = row.chunk_id
+                data = row.chunk
+                if cid < 0 or cid >= total_chunks:
+                    raise RuntimeError(
+                        f"chunk_id {cid} out of range "
+                        f"(total_chunks={total_chunks})"
+                    )
+                if not data:
+                    raise RuntimeError(
+                        f"chunk_id {cid}: corrupt chunk row (empty payload)"
+                    )
+                chunks[cid] = data
+
+        self._scan_partitions(
+            key,
+            range(salt_cardinality),
+            max_concurrency,
+            _collect,
+        )
+
+        try:
+            first_missing = next(i for i, c in enumerate(chunks) if not c)
+        except StopIteration:
+            return chunks
+        raise RuntimeError(
+            f"key={key!r}: missing chunk_id {first_missing} "
+            f"(total_chunks={total_chunks})"
+        )
+
+    # ------------------------------------------------------------------ delete
+    def delete(
+        self,
+        key: bytes,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    ) -> None:
+        """
+        Delete all rows for ``key``.
+
+        Non-sentinel partitions (``salt != 0``) are removed first; the sentinel
+        partition (``salt=0``, carrying ``total_chunks`` / ``salt_cardinality``)
+        is deleted last so a failed delete can be retried.
+        """
+        meta = self._fetch_meta(key)
+        if meta is None:
+            return
+        total_chunks, salt_cardinality = meta
+
+        assert self._stmts is not None
+        delete = self._stmts.delete_partition
+
+        def _delete_tasks(salts: Iterable[int]) -> Iterator[_AsyncTask]:
+            for s in salts:
+                yield _AsyncTask(
+                    submit=functools.partial(
+                        self.session.execute_async, delete, (key, s)
+                    )
+                )
+
+        self._run_async_tasks(
+            _delete_tasks(range(1, salt_cardinality)),
+            max_concurrency,
+            op="DELETE partition",
+        )
+        self._run_async_tasks(
+            _delete_tasks([0]),
+            max_concurrency,
+            op="DELETE partition",
+        )
+
+    # ----------------------------------------------------------------- inspect
+    def describe(
+        self,
+        key: bytes,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    ) -> Optional[BlobLayout]:
+        """
+        Return how a key is laid out across salted partitions.
+
+        When ``max_concurrency > 0`` a true sliding window keeps exactly that
+        many partition SELECT futures in-flight at once; 0 (default) fires all
+        partition SELECTs concurrently without a cap.
+        """
+        meta = self._fetch_meta(key)
+        if meta is None:
+            return None
+        total_chunks, salt_cardinality = meta
+        layout = BlobLayout(
+            total_chunks=total_chunks,
+            salt_cardinality=salt_cardinality,
+            partitions=[
+                PartitionInfo(salt=s, rows=0, bytes=0) for s in range(salt_cardinality)
+            ],
+        )
+
+        def _fill(salt: int, rows: ResultSet) -> None:
+            row_list = list(rows)
+            layout.partitions[salt] = PartitionInfo(
+                salt=salt,
+                rows=len(row_list),
+                bytes=sum(len(r.chunk) for r in row_list),
+            )
+
+        self._scan_partitions(
+            key,
+            range(salt_cardinality),
+            max_concurrency,
+            _fill,
+            op="SELECT partition (describe)",
+        )
+        return layout
+
+
+def _split(blob: bytes, chunk_size: int) -> List[bytes]:
+    return [blob[i:i + chunk_size] for i in range(0, len(blob), chunk_size)]
+
+
+__all__ = [
+    "BlobLayout",
+    "PartitionInfo",
+    "SaltedBlobStore",
+    "DEFAULT_CHUNK_SIZE",
+    "DEFAULT_MAX_SALT",
+    "DEFAULT_MAX_BATCH_BYTES",
+    "DEFAULT_MAX_CONCURRENCY",
+]


### PR DESCRIPTION
This pull request introduces a new Python and C++23 implementation of the large-cell chunking demo, providing a portable and robust build system and comprehensive documentation. The main highlights are the addition of a `CMakeLists.txt` for flexible driver selection and a detailed `README.md` explaining usage, build, and benchmarking.

**Build system and driver support:**

* Added `CMakeLists.txt` that configures the project for C++23, locates the ScyllaDB C++ driver (preferring `scylla-cpp-driver` via `pkg-config`, with fallback to the DataStax driver), and sets up rpath so the runtime linker finds the correct shared library without extra environment configuration. It defines the library and demo/benchmark executables and ensures compatibility across Linux and macOS.

**Documentation and usage:**

* Added a comprehensive `README.md` covering:
  - Project overview and driver support (ScyllaDB and DataStax).
  - Build instructions for Ubuntu, RHEL/Rocky/Fedora, and macOS, including compiler requirements and driver installation.
  - Schema definition and library usage examples.
  - Detailed instructions for running the demo and benchmarking large vs. small blobs, including command-line flags and concurrency controls.
  - Notes on concurrency, resource management, and driver handle ownership for efficient and safe usage.